### PR TITLE
Add imagebuilder tool

### DIFF
--- a/imagebuilder/README.md
+++ b/imagebuilder/README.md
@@ -1,0 +1,68 @@
+ImageBuilder
+============
+
+ImageBuilder is a tool for building an optimized k8s images, currently only supporting AWS.
+
+It is a wrapper around bootstrap-vz (the tool used to build official Debian cloud images).  
+It adds functionality to spin up an instance for building the image, and publishing the image to all regions.
+
+Imagebuilder create an instance to build the image, builds the image as specified by `TemplatePath`, makes the
+image public and copies it to all accessible regions (on AWS), and then shuts down the builder instance.
+Each of these stages can be controlled through flags
+(for example, you might not want use `--publish=false` for an internal image.)
+
+
+## AWS
+
+* `export AWS_PROFILE=...` if you are not using the default profile
+* Create a VPC (with a subnet) and tag the subnet with `k8s.io/role/imagebuilder=1`
+* Create a security group in the VPC, allowing port 22, and tag with `k8s.io/role/imagebuilder=1`
+
+Then:
+
+```
+go install k8s.io/kube-deploy/imagebuilder
+```
+
+Run the image builder:
+```
+${GOPATH}/bin/imagebuilder --config aws.yaml --v=8
+```
+
+It will print the IDs of the image in each region, but it will also tag the image with a Name
+as specified in the template) and this is the easier way to retrieve the image.
+
+## GCE
+
+* Edit gce.yaml, at least to specify the Project and GCSDestination to use
+* Create the GCS bucket in GCSDestination (if it does not exist) `gsutil mb gs://<bucketname>/`
+
+
+Then:
+
+```
+go install k8s.io/kube-deploy/imagebuilder
+```
+
+Run the image builder:
+```
+${GOPATH}/bin/imagebuilder --config gce.yaml --v=8 --publish=false
+```
+
+Note that because GCE does not currently support publishing images, you must pass `--publish=false`.  Also, images on
+GCE are global, so `replicate` does not actually need to do anything.
+
+
+Advanced options
+================
+
+Check out `--help`, but these options control which operations we perform,
+and may be useful for debugging or publishing a lot of images:
+
+* `--up=true/false`, `--down=true/false` control whether we try to create and terminate an instance to do the building
+
+* `--publish=true/false` controls whether we make the image public
+
+* `--replicate=true/false` controls whether we copy the image to all regions
+
+* `--config=<configpath>` lets you configure most options

--- a/imagebuilder/aws.yaml
+++ b/imagebuilder/aws.yaml
@@ -1,0 +1,1 @@
+Cloud: aws

--- a/imagebuilder/bootstrapvz-template.yml
+++ b/imagebuilder/bootstrapvz-template.yml
@@ -1,0 +1,144 @@
+---
+{{ if eq .Cloud "aws" }}
+name: k8s-1.2-debian-{system.release}-{system.architecture}-{provider.virtualization}-ebs-{%Y}-{%m}-{%d}
+{{ else }}
+name: k8s-1.2-debian-{system.release}-{system.architecture}-{%Y}-{%m}-{%d}
+{{ end }}
+provider:
+{{ if eq .Cloud "aws" }}
+  name: ec2
+  virtualization: hvm
+  enhanced_networking: simple
+{{ else if eq .Cloud "gce" }}
+  name: gce
+  gcs_destination: {{ .GCSDestination }}
+  gce_project: {{ .Project }}
+{{ else }}
+  name: {{ .Cloud }}
+{{ end }}
+  description: Kubernetes 1.2 Base Image - Debian {system.release} {system.architecture}
+bootstrapper:
+  workspace: /target
+  # tarball speeds up development, but for prod builds we want to be 100% sure...
+  # tarball: true
+system:
+  release: jessie
+  architecture: amd64
+  # We use grub, not extlinux.
+  # See https://github.com/andsens/bootstrap-vz/issues/182
+  # extlinux makes it harder to modify boot args, and may have reboot problems
+  # bootloader: extlinux
+  bootloader: grub
+  charmap: UTF-8
+  locale: en_US
+  timezone: UTC
+volume:
+{{ if eq .Cloud "aws" }}
+  backing: ebs
+{{ else if eq .Cloud "gce" }}
+  backing: raw
+{{ end }}
+  partitions:
+    type: msdos
+    root:
+      filesystem: ext4
+      size: 8GiB
+packages:
+{{ if eq .Cloud "aws" }}
+  mirror: http://cloudfront.debian.net/debian
+{{ end }}
+  install:
+    # these packages are generaly useful
+    # (and are the ones from the GCE image)
+    - rsync
+    - screen
+    - vim
+{{ if eq .Cloud "aws" }}
+    # these packages are included in the official AWS image
+    - python-boto
+    - python3-boto
+    - apt-transport-https
+    - lvm2
+    - ncurses-term
+    - parted
+    - bootlogd
+    - cloud-init
+    - cloud-utils
+    - gdisk
+    - sysvinit
+    - systemd
+    - systemd-sysv
+
+    # these packages are included in the official image, but we remove them
+    # awscli : we install from pip instead
+{{ end }}
+
+    # These packages would otherwise be installed during first boot
+    - aufs-tools
+    - curl
+    - python-yaml
+    - git
+    - nfs-common
+    - bridge-utils
+    - logrotate
+    - socat
+    - python-apt
+    - apt-transport-https
+    - unattended-upgrades
+    - lvm2
+    - btrfs-tools
+
+{{ if eq .Cloud "aws" }}
+    # cloud-initramfs-growroot will resize the master partition on boot
+    - cloud-initramfs-growroot
+
+    # So we can install the latest awscli
+    - python-pip
+{{ end }}
+
+plugins:
+{{ if eq .Cloud "gce" }}
+  ntp:
+    servers:
+    - metadata.google.internal
+{{ else }}
+  ntp: {}
+{{ end }}
+
+{{ if eq .Cloud "aws" }}
+  cloud_init:
+    metadata_sources: Ec2
+    username: admin
+{{ end }}
+
+  commands:
+    commands:
+{{ if eq .Cloud "aws" }}
+       # Install awscli through python-pip
+       - [ 'chroot', '{root}', 'pip', 'install', 'awscli' ]
+{{ end }}
+
+       # Install docker 1.9.1
+       - [ 'wget', 'http://apt.dockerproject.org/repo/pool/main/d/docker-engine/docker-engine_1.9.1-0~jessie_amd64.deb', '-O', '{root}/tmp/docker.deb' ]
+       - [ '/bin/sh', '-c', 'cd {root}/tmp; echo "c58c39008fd6399177f6b2491222e4438f518d78  docker.deb" | shasum -c -' ]
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --assume-yes libapparmor1' ]
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'DEBIAN_FRONTEND=noninteractive dpkg --install /tmp/docker.deb' ]
+       - [ 'rm', '{root}/tmp/docker.deb' ]
+
+{{ if eq .Cloud "aws" }}
+       # Fix a cloud-init bug where it uses nobootwait
+       # see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=789884
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "mount_default_fields: [~, ~, ''auto'', ''defaults,nofail'', ''0'', ''2'']" > /etc/cloud/cloud.cfg.d/99_kubernetes.cfg' ]
+{{ end }}
+
+       # We perform a full replacement of some grub conf variables:
+       #   GRUB_CMDLINE_LINUX_DEFAULT (add memory cgroup)
+       #   GRUB_TIMEOUT (remove boot delay)
+       # (but leave the old versions commented out for people to see)
+       - [ 'chroot', '{root}', 'touch', '/etc/default/grub' ]
+       - [ 'chroot', '{root}', 'sed', '-i', 's/^GRUB_CMDLINE_LINUX_DEFAULT=/#GRUB_CMDLINE_LINUX_DEFAULT=/g', '/etc/default/grub' ]
+       - [ 'chroot', '{root}', 'sed', '-i', 's/^GRUB_TIMEOUT=/#GRUB_TIMEOUT=/g', '/etc/default/grub' ]
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "# kubernetes image changes" >> /etc/default/grub' ]
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_CMDLINE_LINUX_DEFAULT=\"cgroup_enable=memory oops=panic panic=10 console=ttyS0\"" >> /etc/default/grub' ]
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_TIMEOUT=0" >> /etc/default/grub' ]
+       - [ 'chroot', '{root}', 'update-grub2' ]

--- a/imagebuilder/gce.yaml
+++ b/imagebuilder/gce.yaml
@@ -1,0 +1,7 @@
+Cloud: gce
+
+# GCE Project that you want to use
+Project: <project-name>
+
+# GCS bucket where the image should be uploaded
+GCSDestination: gs://<bucket-name>/

--- a/imagebuilder/main.go
+++ b/imagebuilder/main.go
@@ -1,0 +1,370 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/ghodss/yaml"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/glog"
+	"k8s.io/kube-deploy/imagebuilder/pkg/imagebuilder"
+	"io/ioutil"
+	"path"
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/compute/v1"
+	"strings"
+	"google.golang.org/api/storage/v1"
+	"net/url"
+)
+
+var flagConfig = flag.String("config", "", "Config file to load")
+
+//var flagRegion = flag.String("region", "", "Cloud region to use")
+//var flagImage = flag.String("image", "", "Image to use as builder")
+//var flagSSHKey = flag.String("sshkey", "", "Name of SSH key to use")
+//var flagInstanceType = flag.String("instancetype", "m3.medium", "Instance type to launch")
+//var flagSubnet = flag.String("subnet", "", "Subnet in which to launch")
+//var flagSecurityGroup = flag.String("securitygroup", "", "Security group to use for launch")
+//var flagTemplatePath = flag.String("template", "", "Path to image template")
+
+var flagUp = flag.Bool("up", true, "Set to create instance (if not found)")
+var flagBuild = flag.Bool("build", true, "Set to build image")
+var flagPublish = flag.Bool("publish", true, "Set to publish image")
+var flagReplicate = flag.Bool("replicate", true, "Set to copy the image to all regions")
+var flagDown = flag.Bool("down", true, "Set to shut down instance (if found)")
+
+func loadConfig(dest interface{}, src string) error {
+	data, err := ioutil.ReadFile(src)
+	if err != nil {
+		return fmt.Errorf("error reading file %q: %v", src, err)
+	}
+
+	err = yaml.Unmarshal(data, dest)
+	if err != nil {
+		return fmt.Errorf("error parsing file %q: %v", src, err)
+	}
+
+	return nil
+}
+
+func main() {
+	rand.Seed(time.Now().UTC().UnixNano())
+
+	flag.Set("alsologtostderr", "true")
+	flag.Parse()
+
+	if *flagConfig == "" {
+		glog.Exitf("--config must be specified")
+	}
+
+	var templateContext interface{}
+
+	config := &imagebuilder.Config{}
+	config.InitDefaults()
+	err := loadConfig(config, *flagConfig)
+	if err != nil {
+		glog.Exitf("Error loading config: %v", err)
+	}
+
+	var cloud imagebuilder.Cloud
+	switch (config.Cloud) {
+	case "aws":
+		awsConfig, awsCloud, err := initAWS()
+		if err != nil {
+			glog.Exitf("%v", err)
+		}
+		templateContext = awsConfig
+		cloud = awsCloud
+
+
+	case "gce":
+		if *flagPublish {
+			glog.Exitf("Publishing images is not supported on gce (pass --publish=false)")
+		}
+
+		gceConfig, gceCloud, err := initGCE()
+		if err != nil {
+			glog.Exitf("%v", err)
+		}
+		templateContext = gceConfig
+		cloud = gceCloud
+
+
+	case "":
+		glog.Exitf("Cloud not set")
+	default:
+		glog.Exitf("Unknown cloud: %q", config.Cloud)
+	}
+
+	if *flagBuild && config.TemplatePath == "" {
+		glog.Fatalf("TemplatePath must be provided")
+	}
+
+	var bvzTemplate *imagebuilder.BootstrapVzTemplate
+	var imageName string
+	if config.TemplatePath != "" {
+		templateResolved := path.Join(path.Dir(*flagConfig), config.TemplatePath)
+
+		templateRaw, err := imagebuilder.ReadFile(templateResolved)
+		if err != nil {
+			glog.Fatalf("error reading template: %v", err)
+		}
+
+		templateString, err := imagebuilder.ExpandTemplate(templateResolved, string(templateRaw), templateContext)
+		if err != nil {
+			glog.Fatalf("error executing template: %v", err)
+		}
+
+		bvzTemplate, err = imagebuilder.NewBootstrapVzTemplate(templateString)
+		if err != nil {
+			glog.Fatalf("error parsing template: %v", err)
+		}
+
+		imageName, err = bvzTemplate.BuildImageName()
+		if err != nil {
+			glog.Fatalf("error inferring image name: %v", err)
+		}
+
+		glog.Infof("Parsed template %q; will build image with name %s", config.TemplatePath, imageName)
+	}
+
+	instance, err := cloud.GetInstance()
+	if err != nil {
+		glog.Fatalf("error getting instance: %v", err)
+	}
+
+	if instance == nil && *flagUp {
+		instance, err = cloud.CreateInstance()
+		if err != nil {
+			glog.Fatalf("error creating instance: %v", err)
+		}
+	}
+
+	image, err := cloud.FindImage(imageName)
+	if err != nil {
+		glog.Fatalf("error finding image %q: %v", imageName, err)
+	}
+
+	if image != nil {
+		glog.Infof("found existing image %q", image)
+	}
+
+	if *flagBuild && image == nil {
+		if instance == nil {
+			glog.Fatalf("Instance was not found (specify --up?)")
+		}
+
+		sshConfig := &ssh.ClientConfig{
+			User: config.SSHUsername,
+		}
+
+		if config.SSHPrivateKey == "" {
+			glog.Fatalf("SSHPublicKey is required")
+			// We used to allow the SSH agent, but probably more trouble than it is worth?
+			//sshAgent, err := net.Dial("unix", os.Getenv("SSH_AUTH_SOCK"))
+			//if err != nil {
+			//	glog.Fatalf("error connecting to SSH agent: %v", err)
+			//}
+			//
+			//sshConfig.Auth = append(sshConfig.Auth, ssh.PublicKeysCallback(agent.NewClient(sshAgent).Signers))
+		} else {
+			keyBytes, err := imagebuilder.ReadFile(config.SSHPrivateKey)
+			if err != nil {
+				glog.Exitf("error loading SSH private key: %v", err)
+			}
+			key, err := ssh.ParsePrivateKey(keyBytes)
+			if err != nil {
+				glog.Exitf("error parsing SSH private key: %v", err)
+			}
+
+			sshConfig.Auth = append(sshConfig.Auth, ssh.PublicKeys(key))
+		}
+		sshClient, err := instance.DialSSH(sshConfig)
+		if err != nil {
+			glog.Fatalf("error SSHing to instance: %v", err)
+		}
+		defer sshClient.Close()
+
+		sshHelper := imagebuilder.NewSSH(sshClient)
+
+		builder := imagebuilder.NewBuilder(config, sshHelper)
+		err = builder.RunSetupCommands()
+		if err != nil {
+			glog.Fatalf("error setting up instance: %v", err)
+		}
+
+		extraEnv, err := cloud.GetExtraEnv()
+		if err != nil {
+			glog.Fatalf("error building environment: %v", err)
+		}
+
+		err = builder.BuildImage(bvzTemplate.Bytes(), extraEnv)
+		if err != nil {
+			glog.Fatalf("error building image: %v", err)
+		}
+
+		image, err = cloud.FindImage(imageName)
+		if err != nil {
+			glog.Fatalf("error finding image %q: %v", imageName, err)
+		}
+
+		if image == nil {
+			glog.Fatalf("image not found after build: %q", imageName)
+		}
+	}
+
+	if *flagPublish {
+		if image == nil {
+			glog.Fatalf("image not found: %q", imageName)
+		}
+
+		glog.Infof("Making image public: %v", image)
+
+		err = image.EnsurePublic()
+		if err != nil {
+			glog.Fatalf("error making image public %q: %v", imageName, err)
+		}
+
+		glog.Infof("Made image public: %v", image)
+	}
+
+	if *flagReplicate {
+		if image == nil {
+			glog.Fatalf("image not found: %q", imageName)
+		}
+
+		glog.Infof("Copying image to all regions: %v", image)
+
+		images, err := image.ReplicateImage(*flagPublish)
+		if err != nil {
+			glog.Fatalf("error replicating image %q: %v", imageName, err)
+		}
+
+		for region, imageID := range images {
+			glog.Infof("Image in region %q: %q", region, imageID)
+		}
+	}
+
+	if *flagDown {
+		if instance == nil {
+			glog.Infof("Instance not found / already shutdown")
+		} else {
+			err := instance.Shutdown()
+			if err != nil {
+				glog.Fatalf("error terminating instance: %v", err)
+			}
+		}
+	}
+}
+
+func initAWS() (*imagebuilder.AWSConfig, *imagebuilder.AWSCloud, error) {
+	awsConfig := &imagebuilder.AWSConfig{}
+	awsConfig.InitDefaults()
+	err := loadConfig(awsConfig, *flagConfig)
+	if err != nil {
+		glog.Exitf("Error loading AWS config: %v", err)
+	}
+
+	if awsConfig.Region == "" {
+		glog.Exitf("Region must be set")
+	}
+
+	ec2Client := ec2.New(session.New(), &aws.Config{Region: &awsConfig.Region})
+	awsCloud := imagebuilder.NewAWSCloud(ec2Client, awsConfig)
+
+	return awsConfig, awsCloud, nil
+}
+
+func initGCE() (*imagebuilder.GCEConfig, *imagebuilder.GCECloud, error) {
+	config := &imagebuilder.GCEConfig{}
+	config.InitDefaults()
+	err := loadConfig(config, *flagConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("Error loading GCE config: %v", err)
+	}
+
+	if config.Project == "" {
+		return nil, nil, fmt.Errorf("Project must be set")
+	}
+
+	if config.MachineName == "" {
+		return nil, nil, fmt.Errorf("Name must be set")
+	}
+	if config.Zone == "" {
+		return nil, nil, fmt.Errorf("Zone must be set")
+	}
+	if config.MachineType == "" {
+		return nil, nil, fmt.Errorf("MachineType must be set")
+	}
+
+	if config.Image == "" {
+		return nil, nil, fmt.Errorf("Image must be set")
+	}
+
+	if config.GCSDestination == "" {
+		return nil, nil, fmt.Errorf("GCSDestination must be set")
+	}
+
+	// Avoid common mistake...
+	if !strings.HasSuffix(config.GCSDestination, "/") {
+		return nil, nil, fmt.Errorf("GCSDestination should end in /")
+	}
+	if !strings.HasPrefix(config.GCSDestination, "gs://") {
+		return nil, nil, fmt.Errorf("GCSDestination should start with gs://")
+	}
+
+	ctx := context.Background()
+
+	client, err := google.DefaultClient(ctx, compute.ComputeScope)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error building google API client: %v", err)
+	}
+	computeService, err := compute.New(client)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error building compute API client: %v", err)
+	}
+
+	storageService, err := storage.New(client)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error building compute API client: %v", err)
+	}
+	u, err := url.Parse(config.GCSDestination)
+	if err != nil {
+		return nil, nil, fmt.Errorf("GCSDestination %q is not a well-formed URL: %v", config.GCSDestination, err)
+	}
+	glog.Infof("Checking for bucket %q", u.Host)
+	_, err = storageService.Buckets.Get(u.Host).Do()
+	if err != nil {
+		if imagebuilder.IsGCENotFound(err) {
+			return nil, nil, fmt.Errorf("GCS bucket does not exist: %v", config.GCSDestination)
+		}
+		return nil, nil, fmt.Errorf("Error checking that bucket exists: %v", err)
+	}
+
+	cloud := imagebuilder.NewGCECloud(computeService, config)
+
+	return config, cloud, nil
+}

--- a/imagebuilder/pkg/imagebuilder/aws.go
+++ b/imagebuilder/pkg/imagebuilder/aws.go
@@ -1,0 +1,662 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+// TODO: We should replace most of this code with a fast-install manifest
+// This would also allow more customization, and get rid of half of this code
+// BUT... there's a circular dependency in the PRs here... :-)
+
+package imagebuilder
+
+import (
+	"fmt"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/glog"
+	"crypto/md5"
+	"encoding/hex"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+)
+
+const tagRoleKey = "k8s.io/role/imagebuilder"
+
+// AWSInstance manages an AWS instance, used for building an image
+type AWSInstance struct {
+	instanceID string
+	cloud      *AWSCloud
+	instance   *ec2.Instance
+}
+
+// Shutdown terminates the running instance
+func (i *AWSInstance) Shutdown() error {
+	glog.Infof("Terminating instance %q", i.instanceID)
+	return i.cloud.TerminateInstance(i.instanceID)
+}
+
+// DialSSH establishes an SSH client connection to the instance
+func (i *AWSInstance) DialSSH(config *ssh.ClientConfig) (*ssh.Client, error) {
+	publicIP, err := i.WaitPublicIP()
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		// TODO: Timeout, check error code
+		sshClient, err := ssh.Dial("tcp", publicIP + ":22", config)
+		if err != nil {
+			glog.Warningf("error connecting to SSH on server %q: %v", publicIP, err)
+			time.Sleep(5 * time.Second)
+			continue
+			//	return nil, fmt.Errorf("error connecting to SSH on server %q", publicIP)
+		}
+
+		return sshClient, nil
+	}
+}
+
+// WaitPublicIP waits for the instance to get a public IP, returning it
+func (i *AWSInstance) WaitPublicIP() (string, error) {
+	// TODO: Timeout
+	for {
+		instance, err := i.cloud.describeInstance(i.instanceID)
+		if err != nil {
+			return "", err
+		}
+		publicIP := aws.StringValue(instance.PublicIpAddress)
+		if publicIP != "" {
+			glog.Infof("Instance public IP is %q", publicIP)
+			return publicIP, nil
+		}
+		glog.V(2).Infof("Sleeping before requerying instance for public IP: %q", i.instanceID)
+		time.Sleep(5 * time.Second)
+	}
+}
+
+// AWSCloud is a helper type for talking to an AWS acccount
+type AWSCloud struct {
+	config *AWSConfig
+
+	ec2    *ec2.EC2
+}
+
+var _ Cloud = &AWSCloud{}
+
+func NewAWSCloud(ec2 *ec2.EC2, config *AWSConfig) *AWSCloud {
+	return &AWSCloud{
+		ec2: ec2,
+		config: config,
+	}
+}
+
+func (a*AWSCloud) GetExtraEnv() (map[string]string, error) {
+	credentials := a.ec2.Config.Credentials
+	if credentials == nil {
+		return nil, fmt.Errorf("unable to determine EC2 credentials")
+	}
+
+	creds, err := credentials.Get()
+	if err != nil {
+		return nil, fmt.Errorf("error fetching EC2 credentials: %v", err)
+	}
+
+	env := make(map[string]string)
+	env["AWS_ACCESS_KEY"] = creds.AccessKeyID
+	env["AWS_SECRET_KEY"] = creds.SecretAccessKey
+
+	return env, nil
+}
+
+func (a *AWSCloud) describeInstance(instanceID string) (*ec2.Instance, error) {
+	request := &ec2.DescribeInstancesInput{}
+	request.InstanceIds = []*string{&instanceID}
+
+	glog.V(2).Infof("AWS DescribeInstances InstanceId=%q", instanceID)
+	response, err := a.ec2.DescribeInstances(request)
+	if err != nil {
+		return nil, fmt.Errorf("error making AWS DescribeInstances call: %v", err)
+	}
+
+	for _, reservation := range response.Reservations {
+		for _, instance := range reservation.Instances {
+			if aws.StringValue(instance.InstanceId) != instanceID {
+				panic("Unexpected InstanceId found")
+			}
+
+			return instance, err
+		}
+	}
+	return nil, nil
+}
+
+// TerminateInstance terminates the specified instance
+func (a *AWSCloud) TerminateInstance(instanceID string) error {
+	request := &ec2.TerminateInstancesInput{}
+	request.InstanceIds = []*string{&instanceID}
+
+	glog.V(2).Infof("AWS TerminateInstances instanceID=%q", instanceID)
+	_, err := a.ec2.TerminateInstances(request)
+	return err
+}
+
+// GetInstance returns the AWS instance matching our tags, or nil if not found
+func (a *AWSCloud) GetInstance() (Instance, error) {
+	request := &ec2.DescribeInstancesInput{}
+	request.Filters = []*ec2.Filter{
+		{
+			Name:   aws.String("tag-key"),
+			Values: aws.StringSlice([]string{tagRoleKey}),
+		},
+	}
+
+	glog.V(2).Infof("AWS DescribeInstances Filter:tag-key=%s", tagRoleKey)
+	response, err := a.ec2.DescribeInstances(request)
+	if err != nil {
+		return nil, fmt.Errorf("error making AWS DescribeInstances call: %v", err)
+	}
+
+	for _, reservation := range response.Reservations {
+		for _, instance := range reservation.Instances {
+			instanceID := aws.StringValue(instance.InstanceId)
+			if instanceID == "" {
+				panic("Found instance with empty instance ID")
+			}
+
+			glog.Infof("Found existing instance: %q", instanceID)
+			return &AWSInstance{
+				cloud:      a,
+				instance:   instance,
+				instanceID: instanceID,
+			}, nil
+		}
+	}
+
+	return nil, nil
+}
+
+
+
+// findSubnet returns a subnet tagged with our role tag, if one exists
+func (c *AWSCloud) findSubnet() (*ec2.Subnet, error) {
+	request := &ec2.DescribeSubnetsInput{}
+	request.Filters = []*ec2.Filter{
+		{
+			Name:   aws.String("tag-key"),
+			Values: aws.StringSlice([]string{tagRoleKey}),
+		},
+	}
+
+	glog.V(2).Infof("AWS DescribeSubnets Filter:tag-key=%s", tagRoleKey)
+	response, err := c.ec2.DescribeSubnets(request)
+	if err != nil {
+		return nil, fmt.Errorf("error making AWS DescribeSubnets call: %v", err)
+	}
+
+	for _, subnet := range response.Subnets {
+		return subnet, nil
+	}
+
+	return nil, nil
+}
+
+
+// findSecurityGroup returns a security group tagged with our role tag, if one exists
+func (c *AWSCloud) findSecurityGroup(vpcID string) (*ec2.SecurityGroup, error) {
+	request := &ec2.DescribeSecurityGroupsInput{}
+	request.Filters = []*ec2.Filter{
+		{
+			Name:   aws.String("tag-key"),
+			Values: aws.StringSlice([]string{tagRoleKey}),
+		},
+		{
+			Name:   aws.String("vpc-id"),
+			Values: aws.StringSlice([]string{vpcID}),
+		},
+	}
+
+	glog.V(2).Infof("AWS DescribeSecurityGroups Filter:tag-key=%s", tagRoleKey)
+	response, err := c.ec2.DescribeSecurityGroups(request)
+	if err != nil {
+		return nil, fmt.Errorf("error making AWS DescribeSecurityGroups call: %v", err)
+	}
+
+	for _, sg := range response.SecurityGroups {
+		return sg, nil
+	}
+
+	return nil, nil
+}
+
+
+
+// describeSubnet returns a subnet with the specified id, if it exists
+func (c *AWSCloud) describeSubnet(subnetID string) (*ec2.Subnet, error) {
+	request := &ec2.DescribeSubnetsInput{}
+	request.SubnetIds = []*string{&subnetID}
+
+	glog.V(2).Infof("AWS DescribeSubnetsInput ID:%q", subnetID)
+	response, err := c.ec2.DescribeSubnets(request)
+	if err != nil {
+		return nil, fmt.Errorf("error making AWS DescribeSubnets call: %v", err)
+	}
+
+	for _, subnet := range response.Subnets {
+		return subnet, nil
+	}
+
+	return nil, nil
+}
+
+// TagResource adds AWS tags to the specified resource
+func (a *AWSCloud) TagResource(resourceId string, tags ...*ec2.Tag) error {
+	request := &ec2.CreateTagsInput{}
+	request.Resources = aws.StringSlice([]string{resourceId})
+	request.Tags = tags
+
+	glog.V(2).Infof("AWS CreateTags Resource=%q", resourceId)
+	_, err := a.ec2.CreateTags(request)
+	if err != nil {
+		return fmt.Errorf("error making AWS CreateTag call: %v", err)
+	}
+
+	return err
+}
+
+func (c*AWSCloud) findSSHKey(name string) (*ec2.KeyPairInfo, error) {
+	request := &ec2.DescribeKeyPairsInput{
+		KeyNames: []*string{&name},
+	}
+
+	response, err := c.ec2.DescribeKeyPairs(request)
+	if awsErr, ok := err.(awserr.Error); ok {
+		if awsErr.Code() == "InvalidKeyPair.NotFound" {
+			return nil, nil
+		}
+	}
+	if err != nil {
+		return nil, fmt.Errorf("error listing AWS KeyPairs: %v", err)
+	}
+
+	if response == nil || len(response.KeyPairs) == 0 {
+		return nil, nil
+	}
+
+	if len(response.KeyPairs) != 1 {
+		return nil, fmt.Errorf("Found multiple AWS KeyPairs with Name %q", name)
+	}
+
+	k := response.KeyPairs[0]
+
+	return k, nil
+}
+func (c*AWSCloud) ensureSSHKey() (string, error) {
+	publicKey, err := ReadFile(c.config.SSHPublicKey)
+	if err != nil {
+		return "", err
+	}
+
+	// TODO: Use real OpenSSH or AWS fingerprint?
+	hashBytes := md5.Sum([]byte(publicKey))
+	hash := hex.EncodeToString(hashBytes[:])
+
+	name := "imagebuilder-" + hash
+
+	key, err := c.findSSHKey(name)
+	if err != nil {
+		return "", err
+	}
+
+	if key != nil {
+		return *key.KeyName, nil
+	}
+
+	glog.V(2).Infof("Creating AWS KeyPair with Name:%q", name)
+
+	request := &ec2.ImportKeyPairInput{}
+	request.KeyName = &name
+	request.PublicKeyMaterial = []byte(publicKey)
+
+	response, err := c.ec2.ImportKeyPair(request)
+	if err != nil {
+		return "", fmt.Errorf("error creating AWS KeyPair: %v", err)
+	}
+
+	return *response.KeyName, nil
+}
+
+
+// CreateInstance creates an instance for building an image instance
+func (c *AWSCloud) CreateInstance() (Instance, error) {
+	var err error
+	sshKeyName := c.config.SSHKeyName
+	if sshKeyName == "" {
+		sshKeyName, err = c.ensureSSHKey()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	subnetID := c.config.SubnetID
+	if subnetID == "" {
+		subnet, err := c.findSubnet()
+		if err != nil {
+			return nil, err
+		}
+		if subnet != nil {
+			subnetID = aws.StringValue(subnet.SubnetId)
+		}
+		if subnetID == "" {
+			return nil, fmt.Errorf("SubnetID must be specified, or a subnet must be tagged with %q", tagRoleKey)
+		}
+	}
+
+	subnet, err := c.describeSubnet(subnetID)
+	if err != nil {
+		return nil, err
+	}
+	if subnet == nil {
+		return nil, fmt.Errorf("could not find subnet %q", subnetID)
+	}
+
+	if c.config.ImageID == "" {
+		return nil, fmt.Errorf("ImageID must be specified")
+	}
+
+	if c.config.InstanceType == "" {
+		return nil, fmt.Errorf("InstanceType must be specified")
+	}
+
+	securityGroupID := c.config.SecurityGroupID
+	if securityGroupID == "" {
+		vpcID := *subnet.VpcId
+		securityGroup, err := c.findSecurityGroup(vpcID)
+		if err != nil {
+			return nil, err
+		}
+		if securityGroup != nil {
+			securityGroupID = aws.StringValue(securityGroup.GroupId)
+		}
+		if securityGroupID == "" {
+			return nil, fmt.Errorf("SecurityGroupID must be specified, or a security group for VPC %q must be tagged with %q", vpcID, tagRoleKey)
+		}
+	}
+
+	request := &ec2.RunInstancesInput{}
+	request.ImageId = aws.String(c.config.ImageID)
+	request.KeyName = aws.String(sshKeyName)
+	request.InstanceType = aws.String(c.config.InstanceType)
+	request.NetworkInterfaces = []*ec2.InstanceNetworkInterfaceSpecification{
+		{
+			DeviceIndex:              aws.Int64(0),
+			AssociatePublicIpAddress: aws.Bool(true),
+			SubnetId:                 aws.String(subnetID),
+			Groups:                   aws.StringSlice([]string{securityGroupID}),
+		},
+	}
+	request.MaxCount = aws.Int64(1)
+	request.MinCount = aws.Int64(1)
+
+	glog.V(2).Infof("AWS RunInstances InstanceType=%q ImageId=%q KeyName=%q", c.config.InstanceType, c.config.ImageID, sshKeyName)
+	response, err := c.ec2.RunInstances(request)
+	if err != nil {
+		return nil, fmt.Errorf("error making AWS RunInstances call: %v", err)
+	}
+
+	for _, instance := range response.Instances {
+		instanceID := aws.StringValue(instance.InstanceId)
+		if instanceID == "" {
+			return nil, fmt.Errorf("AWS RunInstances call returned empty InstanceId")
+		}
+		err := c.TagResource(instanceID, &ec2.Tag{
+			Key: aws.String(tagRoleKey), Value: aws.String("'"),
+		})
+		if err != nil {
+			glog.Warningf("Tagging instance %q failed; will terminate to prevent leaking", instanceID)
+			e2 := c.TerminateInstance(instanceID)
+			if e2 != nil {
+				glog.Warningf("error terminating instance %q, will leak instance", instanceID)
+			}
+			return nil, err
+		}
+
+		return &AWSInstance{
+			cloud:      c,
+			instance:   instance,
+			instanceID: instanceID,
+		}, nil
+	}
+	return nil, fmt.Errorf("instance was not returned by AWS RunInstances")
+}
+
+// FindImage finds a registered image, matching by the name tag
+func (a *AWSCloud) FindImage(imageName string) (Image, error) {
+	image, err := findAWSImage(a.ec2, imageName)
+	if err != nil {
+		return nil, err
+	}
+
+	if image == nil {
+		return nil, nil
+	}
+
+	imageID := aws.StringValue(image.ImageId)
+	if imageID == "" {
+		return nil, fmt.Errorf("found image with empty ImageId: %q", imageName)
+	}
+
+	return &AWSImage{
+		ec2:   a.ec2,
+		region: a.config.Region,
+		image:   image,
+		imageID: imageID,
+	}, nil
+}
+
+func findAWSImage(client *ec2.EC2, imageName string) (*ec2.Image, error) {
+	request := &ec2.DescribeImagesInput{}
+	request.Filters = []*ec2.Filter{
+		{
+			Name:   aws.String("name"),
+			Values: aws.StringSlice([]string{imageName}),
+		},
+	}
+	request.Owners = aws.StringSlice([]string{"self"})
+
+	glog.V(2).Infof("AWS DescribeImages Filter:Name=%q, Owner=self", imageName)
+	response, err := client.DescribeImages(request)
+	if err != nil {
+		return nil, fmt.Errorf("error making AWS DescribeImages call: %v", err)
+	}
+
+	if len(response.Images) == 0 {
+		return nil, nil
+	}
+
+	if len(response.Images) != 1 {
+		// Image names are unique per user...
+		return nil, fmt.Errorf("found multiple matching images for name: %q", imageName)
+	}
+
+	image := response.Images[0]
+	return image, nil
+}
+
+// AWSImage represents an AMI on AWS
+type AWSImage struct {
+	ec2     *ec2.EC2
+	region  string
+	//cloud   *AWSCloud
+	image   *ec2.Image
+	imageID string
+}
+
+// ID returns the AWS identifier for the image
+func (i *AWSImage) ID() string {
+	return i.imageID
+}
+
+// String returns a string representation of the image
+func (i *AWSImage) String() string {
+	return "AWSImage[id=" + i.imageID + "]"
+}
+
+// EnsurePublic makes the image accessible outside the current account
+func (i *AWSImage) EnsurePublic() error {
+	return i.ensurePublic()
+}
+
+func (i*AWSImage) waitStatusAvailable() error {
+	imageID := i.imageID
+
+	for {
+		// TODO: Timeout
+		request := &ec2.DescribeImagesInput{}
+		request.ImageIds = aws.StringSlice([]string{imageID})
+
+		glog.V(2).Infof("AWS DescribeImages ImageId=%q", imageID)
+		response, err := i.ec2.DescribeImages(request)
+		if err != nil {
+			return fmt.Errorf("error making AWS DescribeImages call: %v", err)
+		}
+
+		if len(response.Images) == 0 {
+			return fmt.Errorf("image not found %q", imageID)
+		}
+
+		if len(response.Images) != 1 {
+			return fmt.Errorf("multiple imags found with ID %q", imageID)
+		}
+
+		image := response.Images[0]
+
+		state := aws.StringValue(image.State)
+		glog.V(2).Infof("image state %q", state)
+		if state == "available" {
+			return nil
+		}
+		glog.Infof("Image not yet available (%s); waiting", imageID)
+		time.Sleep(10 * time.Second)
+	}
+}
+
+func (i*AWSImage) ensurePublic() error {
+	err := i.waitStatusAvailable()
+	if err != nil {
+		return err
+	}
+
+	// This is idempotent, so just always do it
+	request := &ec2.ModifyImageAttributeInput{}
+	request.ImageId = aws.String(i.imageID)
+	request.LaunchPermission = &ec2.LaunchPermissionModifications{
+		Add: []*ec2.LaunchPermission{
+			{Group: aws.String("all")},
+		},
+	}
+
+	glog.V(2).Infof("AWS ModifyImageAttribute Image=%q, LaunchPermission All", i.image)
+	_, err = i.ec2.ModifyImageAttribute(request)
+	if err != nil {
+		return fmt.Errorf("error making image public %q: %v", i.imageID, err)
+	}
+
+	return err
+}
+
+// ReplicateImage copies the image to all accessable AWS regions
+func (i *AWSImage) ReplicateImage(makePublic bool) (map[string]Image, error) {
+	imagesByRegion := make(map[string]Image)
+
+	glog.V(2).Infof("AWS DescribeRegions")
+	request := &ec2.DescribeRegionsInput{}
+	response, err := i.ec2.DescribeRegions(request)
+	if err != nil {
+		return nil, fmt.Errorf("error listing ec2 regions: %v", err)
+
+	}
+	imagesByRegion[i.region] = i
+
+	for _, region := range response.Regions {
+		regionName := aws.StringValue(region.RegionName)
+		if imagesByRegion[regionName] != nil {
+			continue
+		}
+
+		imageID, err := i.copyImageToRegion(regionName)
+		if err != nil {
+			return nil, fmt.Errorf("error copying image to region %q: %v", regionName, err)
+		}
+		targetEC2 := ec2.New(session.New(), &aws.Config{Region: &regionName})
+		imagesByRegion[regionName] = &AWSImage{
+			ec2: targetEC2,
+			region: regionName,
+			imageID: imageID,
+		}
+	}
+
+	if makePublic {
+		for regionName, image := range imagesByRegion {
+			err := image.EnsurePublic()
+			if err != nil {
+				return nil, fmt.Errorf("error making image public in region %q: %v", regionName, err)
+			}
+		}
+	}
+
+	return imagesByRegion, nil
+}
+
+func (i *AWSImage) copyImageToRegion(regionName string) (string, error) {
+	targetEC2 := ec2.New(session.New(), &aws.Config{Region: &regionName})
+
+	imageName := aws.StringValue(i.image.Name)
+	description := aws.StringValue(i.image.Description)
+
+	destImage, err := findAWSImage(targetEC2, imageName)
+	if err != nil {
+		return "", err
+	}
+
+	var imageID string
+
+	// We've already copied the image
+	if destImage != nil {
+		imageID = aws.StringValue(destImage.ImageId)
+	} else {
+		token := imageName + "-" + regionName
+
+		request := &ec2.CopyImageInput{
+			ClientToken:   aws.String(token),
+			Description:   aws.String(description),
+			Name:          aws.String(imageName),
+			SourceImageId: aws.String(i.imageID),
+			SourceRegion:  aws.String(i.region),
+		}
+		glog.V(2).Infof("AWS CopyImage Image=%q, Region=%q", i.imageID, regionName)
+		response, err := targetEC2.CopyImage(request)
+		if err != nil {
+			return "", fmt.Errorf("error copying image to region %q: %v", regionName, err)
+		}
+
+		imageID = aws.StringValue(response.ImageId)
+	}
+
+	return imageID, nil
+}

--- a/imagebuilder/pkg/imagebuilder/bootstrapvz.go
+++ b/imagebuilder/pkg/imagebuilder/bootstrapvz.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package imagebuilder
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v2"
+)
+
+// NewBootstrapVzTemplate builds a BootstrapVzTemplate from a file
+func NewBootstrapVzTemplate(data string) (*BootstrapVzTemplate, error) {
+	m := make(map[interface{}]interface{})
+
+	err := yaml.Unmarshal([]byte(data), &m)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing template: %v", err)
+	}
+	return &BootstrapVzTemplate{data: m, raw: []byte(data)}, nil
+}
+
+// BootstrapVzTemplate represents a bootstrap-vz template file
+type BootstrapVzTemplate struct {
+	data map[interface{}]interface{}
+	raw  []byte
+}
+
+// Bytes returns the template contents
+func (t *BootstrapVzTemplate) Bytes() []byte {
+	return t.raw
+}
+
+// BuildImageName computes the name of the image that will be built
+func (t *BootstrapVzTemplate) BuildImageName() (string, error) {
+	name, err := t.getString("name")
+	if err != nil {
+		return "", err
+	}
+	if name == "" {
+		return "", fmt.Errorf("name not found in template")
+	}
+	regex := regexp.MustCompile("{([^}]*)}")
+
+	now := time.Now().UTC()
+
+	var replaceErr error
+
+	replacer := func(path string) string {
+		// Remove { and }
+		path = path[1 : len(path) - 1]
+
+		if path == "" {
+			return ""
+		}
+
+		if path[0] == '%' {
+			switch path {
+			case "%Y":
+				return strconv.Itoa(now.Year())
+			case "%m":
+				return fmt.Sprintf("%02d", now.Month())
+			case "%d":
+				return fmt.Sprintf("%02d", now.Day())
+			default:
+				replaceErr = fmt.Errorf("unknown template specifier: %q", path)
+				return ""
+			}
+		} else {
+			v, err := t.getString(path)
+			if err != nil {
+				replaceErr = fmt.Errorf("error replacing template spec %q: %v", path, err)
+				return ""
+			}
+			return v
+		}
+	}
+
+	name = regex.ReplaceAllStringFunc(name, replacer)
+	if replaceErr != nil {
+		return "", replaceErr
+	}
+	return name, nil
+}
+
+func (t *BootstrapVzTemplate) getString(path string) (string, error) {
+	tokens := strings.Split(path, ".")
+	pos := t.data
+	for i, token := range tokens {
+		next, found := pos[token]
+		if !found {
+			return "", nil
+		}
+
+		if (i + 1) == len(tokens) {
+			s, ok := next.(string)
+			if !ok {
+				return "", fmt.Errorf("Expected string, found %T at %q", next, path)
+			}
+			return s, nil
+		}
+
+		m, ok := next.(map[interface{}]interface{})
+		if !ok {
+			return "", fmt.Errorf("Expected map, found %T at %q", next, path)
+		}
+		pos = m
+	}
+
+	panic("unreachable")
+}

--- a/imagebuilder/pkg/imagebuilder/builder.go
+++ b/imagebuilder/pkg/imagebuilder/builder.go
@@ -1,0 +1,72 @@
+package imagebuilder
+
+import (
+	"fmt"
+	"path"
+	"bytes"
+	"math/rand"
+)
+
+type Builder struct {
+	config *Config
+	ssh    *SSH
+}
+
+func NewBuilder(config *Config, ssh *SSH) *Builder {
+	return &Builder{
+		config: config,
+		ssh: ssh,
+	}
+}
+
+func (b*Builder) RunSetupCommands() error {
+	for _, c := range b.config.SetupCommands {
+		if err := b.ssh.Exec(c); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (b*Builder)  BuildImage(template []byte, extraEnv map[string]string) error {
+	tmpdir := fmt.Sprintf("/tmp/imagebuilder-%d", rand.Int63())
+	err := b.ssh.SCPMkdir(tmpdir, 0755)
+	if err != nil {
+		return err
+	}
+	defer b.ssh.Exec("rm -rf " + tmpdir)
+
+	logdir := path.Join(tmpdir, "logs")
+	err = b.ssh.SCPMkdir(logdir, 0755)
+	if err != nil {
+		return err
+	}
+
+	//err = ssh.Exec("git clone https://github.com/andsens/bootstrap-vz.git " + tmpdir + "/bootstrap-vz")
+	err = b.ssh.Exec("git clone " + b.config.BootstrapVZRepo  + " -b " + b.config.BootstrapVZBranch + " " + tmpdir + "/bootstrap-vz")
+	if err != nil {
+		return err
+	}
+
+	err = b.ssh.SCPPut(tmpdir + "/template.yml", len(template), bytes.NewReader(template), 0644)
+	if err != nil {
+		return err
+	}
+
+	// TODO: Create dir for logs, log to that dir using --log, collect logs from that dir
+	cmd := b.ssh.Command(fmt.Sprintf("./bootstrap-vz/bootstrap-vz --debug --log %q ./template.yml", logdir))
+	cmd.Cwd = tmpdir
+	for k, v := range extraEnv {
+		cmd.Env[k] = v
+	}
+	cmd.Sudo = true
+	err = cmd.Run()
+	if err != nil {
+		return err
+	}
+
+	// TODO: Capture debug output file?
+	return nil
+}
+

--- a/imagebuilder/pkg/imagebuilder/cloud.go
+++ b/imagebuilder/pkg/imagebuilder/cloud.go
@@ -1,0 +1,22 @@
+package imagebuilder
+
+import "golang.org/x/crypto/ssh"
+
+type Cloud interface {
+	GetInstance() (Instance, error)
+	CreateInstance() (Instance, error)
+
+	FindImage(imageName string) (Image, error)
+
+	GetExtraEnv() (map[string]string, error)
+}
+
+type Instance interface {
+	DialSSH(config *ssh.ClientConfig) (*ssh.Client, error)
+	Shutdown() error
+}
+
+type Image interface {
+	EnsurePublic() error
+	ReplicateImage(makePublic bool) (map[string]Image, error)
+}

--- a/imagebuilder/pkg/imagebuilder/config.go
+++ b/imagebuilder/pkg/imagebuilder/config.go
@@ -1,0 +1,74 @@
+package imagebuilder
+
+type Config struct {
+	Cloud             string
+	TemplatePath      string
+	SetupCommands     []string
+
+	BootstrapVZRepo   string
+	BootstrapVZBranch string
+
+	SSHUsername       string
+	SSHPublicKey      string
+	SSHPrivateKey     string
+}
+
+func (c*Config) InitDefaults() {
+	// At least until https://github.com/andsens/bootstrap-vz/pull/316 merges
+	// Maybe we should have our own fork anyway though
+	c.BootstrapVZRepo = "https://github.com/justinsb/bootstrap-vz.git"
+	c.BootstrapVZBranch = "master"
+
+	c.SSHUsername = "admin"
+	c.SSHPublicKey = "~/.ssh/id_rsa.pub"
+	c.SSHPrivateKey = "~/.ssh/id_rsa"
+
+	c.TemplatePath = "bootstrapvz-template.yml"
+	c.SetupCommands = []string{
+		"sudo apt-get update",
+		"sudo apt-get install --yes git python debootstrap python-pip kpartx parted",
+		"sudo pip install termcolor jsonschema fysom docopt pyyaml boto",
+	}
+}
+
+type AWSConfig struct {
+	Config
+
+	Region          string
+	ImageID         string
+	InstanceType    string
+	SSHKeyName      string
+	SubnetID        string
+	SecurityGroupID string
+}
+
+func (c*AWSConfig) InitDefaults() {
+	c.Config.InitDefaults()
+	c.Region = "us-east-1"
+	// Debian 8.4 us-east-1 from https://wiki.debian.org/Cloud/AmazonEC2Image/Jessie
+	c.ImageID = "ami-c8bda8a2"
+	c.InstanceType = "m3.medium"
+}
+
+type GCEConfig struct {
+	Config
+
+	// To create an image on GCE, we have to upload it to a bucket first
+	GCSDestination string
+
+	Project        string
+	Zone           string
+	MachineName    string
+
+	MachineType    string
+	Image          string
+}
+
+func (c*GCEConfig) InitDefaults() {
+	c.Config.InitDefaults()
+	c.MachineName = "k8s-imagebuilder"
+	c.Zone = "us-central1-f"
+	c.MachineType = "n1-standard-2"
+	c.Image = "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20160329"
+}
+

--- a/imagebuilder/pkg/imagebuilder/gce.go
+++ b/imagebuilder/pkg/imagebuilder/gce.go
@@ -1,0 +1,303 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package imagebuilder
+
+import (
+	"google.golang.org/api/compute/v1"
+	"fmt"
+	"github.com/golang/glog"
+	"golang.org/x/crypto/ssh"
+	"time"
+	"google.golang.org/api/googleapi"
+)
+
+// TODO: We should replace most of this code with a fast-install manifest
+// This would also allow more customization, and get rid of half of this code
+// BUT... there's a circular dependency in the PRs here... :-)
+
+// GCEInstance manages an GCE instance, used for building an image
+type GCEInstance struct {
+	cloud    *GCECloud
+	name     string
+	instance *compute.Instance
+}
+
+// Shutdown terminates the running instance
+func (i *GCEInstance) Shutdown() error {
+	glog.Infof("Terminating instance %q", i.name)
+	return i.cloud.deleteInstance(i.name)
+}
+
+// DialSSH establishes an SSH client connection to the instance
+func (i *GCEInstance) DialSSH(config *ssh.ClientConfig) (*ssh.Client, error) {
+	publicIP, err := i.WaitPublicIP()
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		// TODO: Timeout, check error code
+		sshClient, err := ssh.Dial("tcp", publicIP + ":22", config)
+		if err != nil {
+			glog.Warningf("error connecting to SSH on server %q: %v", publicIP, err)
+			time.Sleep(5 * time.Second)
+			continue
+			//	return nil, fmt.Errorf("error connecting to SSH on server %q", publicIP)
+		}
+
+		return sshClient, nil
+	}
+}
+
+// WaitPublicIP waits for the instance to get a public IP, returning it
+func (i *GCEInstance) WaitPublicIP() (string, error) {
+	// TODO: Timeout
+	for {
+		instance, err := i.cloud.describeInstance(i.name)
+		if err != nil {
+			return "", err
+		}
+
+		for _, ni := range instance.NetworkInterfaces {
+			for _, ac := range ni.AccessConfigs {
+				if ac.NatIP != "" {
+					glog.Infof("Instance public IP is %q", ac.NatIP)
+					return ac.NatIP, nil
+				}
+			}
+		}
+		glog.V(2).Infof("Sleeping before requerying instance for public IP: %q", i.name)
+		time.Sleep(5 * time.Second)
+	}
+}
+
+// GCECloud is a helper type for talking to an GCE acccount
+type GCECloud struct {
+	config        *GCEConfig
+
+	computeClient *compute.Service
+}
+
+var _ Cloud = &GCECloud{}
+
+func NewGCECloud(computeClient *compute.Service, config *GCEConfig) *GCECloud {
+	return &GCECloud{
+		computeClient: computeClient,
+		config: config,
+	}
+}
+
+func (a*GCECloud) GetExtraEnv() (map[string]string, error) {
+	// No extra env needed on GCE
+	env := make(map[string]string)
+	return env, nil
+}
+
+func IsGCENotFound(err error) bool {
+	apiErr, ok := err.(*googleapi.Error)
+	if !ok {
+		return false
+	}
+	return apiErr.Code == 404
+}
+
+func (c *GCECloud) describeInstance(name string) (*compute.Instance, error) {
+	glog.V(2).Infof("GCE Instances List Name=%q", name)
+	instances, err := c.computeClient.Instances.List(c.config.Project, c.config.Zone).Filter("name eq " + name).Do()
+	if err != nil {
+		return nil, fmt.Errorf("error making GCE Instances List call: %v", err)
+	}
+
+	if len(instances.Items) == 0 {
+		return nil, nil
+	}
+	if len(instances.Items) != 1 {
+		return nil, fmt.Errorf("found multiple instances with name %q", name)
+	}
+	return instances.Items[0], nil
+}
+
+// deleteInstance terminates the specified instance
+func (c *GCECloud) deleteInstance(name string) error {
+	glog.V(2).Infof("GCE Delete Instances name=%q", name)
+	_, err := c.computeClient.Instances.Delete(c.config.Project, c.config.Zone, name).Do()
+	if err != nil {
+		return fmt.Errorf("error terminating instance %q: %v", name, err)
+	}
+	return nil
+}
+
+// GetInstance returns the GCE instance matching our tags, or nil if not found
+func (c *GCECloud) GetInstance() (Instance, error) {
+	name := c.config.MachineName
+
+	instance, err := c.describeInstance(name)
+	if err != nil {
+		return nil, err
+	}
+
+	if instance != nil {
+		glog.Infof("Found existing instance: %q", instance.Name)
+		return &GCEInstance{
+			cloud:      c,
+			instance:   instance,
+			name: instance.Name,
+		}, nil
+	}
+
+	return nil, nil
+}
+
+// CreateInstance creates an instance for building an image instance
+func (c *GCECloud) CreateInstance() (Instance, error) {
+	name := c.config.MachineName
+	zone := c.config.Zone
+
+	machineType := "zones/" + zone + "/machineTypes/" + c.config.MachineType
+	glog.Infof("creating instance with machinetype %s", machineType)
+
+	var disks []*compute.AttachedDisk
+	disks = append(disks, &compute.AttachedDisk{
+		InitializeParams: &compute.AttachedDiskInitializeParams{
+			SourceImage: c.config.Image,
+			DiskType: "zones/" + zone + "/diskTypes/pd-ssd",
+		},
+		Boot:       true,
+		DeviceName: "disk-0",
+		Index:      0,
+		AutoDelete: true,
+		Mode:       "READ_WRITE",
+		Type:       "PERSISTENT",
+	})
+
+	metadata := &compute.Metadata{}
+
+	if c.config.SSHPublicKey != "" {
+		publicKey, err := ReadFile(c.config.SSHPublicKey)
+		if err != nil {
+			return nil, err
+		}
+		sshKey := "admin:" + string(publicKey)
+
+		metadata.Items = append(metadata.Items, &compute.MetadataItems{
+			Key: "ssh-keys",
+			Value: &sshKey,
+		})
+	}
+
+	scopes := []string{
+		"https://www.googleapis.com/auth/devstorage.read_write",
+		"https://www.googleapis.com/auth/compute",
+	}
+
+	instance := &compute.Instance{
+		Name: name,
+		NetworkInterfaces: []*compute.NetworkInterface{
+			{
+				AccessConfigs: []*compute.AccessConfig{
+					{
+						Name: "nat",
+						Type: "ONE_TO_ONE_NAT",
+					},
+				},
+			},
+		},
+		MachineType:        machineType,
+		Disks: disks,
+		Metadata: metadata,
+		ServiceAccounts: []*compute.ServiceAccount{
+			{
+				Email:  "default",
+				Scopes: scopes,
+			},
+		},
+	}
+	_, err := c.computeClient.Instances.Insert(c.config.Project, c.config.Zone, instance).Do()
+	if err != nil {
+		return nil, fmt.Errorf("error running instance: %v", err)
+	}
+	return &GCEInstance{
+		cloud: c,
+		name: name,
+	}, nil
+}
+
+// FindImage finds a registered image, matching by the name tag
+func (c *GCECloud) FindImage(imageName string) (Image, error) {
+	image, err := findGCEImage(c.computeClient, c.config.Project, imageName)
+	if err != nil {
+		return nil, err
+	}
+
+	if image == nil {
+		return nil, nil
+	}
+
+	return &GCEImage{
+		computeClient:   c.computeClient,
+		name: imageName,
+		//image:   image,
+	}, nil
+}
+
+func findGCEImage(computeClient *compute.Service, project string, imageName string) (*compute.Image, error) {
+	images, err := computeClient.Images.List(project).Filter("name eq " + imageName).Do()
+	if err != nil {
+		return nil, fmt.Errorf("error listing images: %v", err)
+	}
+
+	glog.V(2).Infof("GCE Images List Filter:Name=%q", imageName)
+
+	if len(images.Items) == 0 {
+		return nil, nil
+	}
+
+	if len(images.Items) != 1 {
+		return nil, fmt.Errorf("found multiple matching images for name: %q", imageName)
+	}
+
+	return images.Items[0], nil
+}
+
+// GCEImage represents an image on GCE
+type GCEImage struct {
+	computeClient *compute.Service
+	name          string
+}
+
+var _ Image = &GCEImage{}
+
+// String returns a string representation of the image
+func (i *GCEImage) String() string {
+	return "GCEImage[" + i.name + "]"
+}
+
+// EnsurePublic makes the image accessible outside the current account
+func (i *GCEImage) EnsurePublic() error {
+	return fmt.Errorf("GCE does not currently support public images")
+}
+
+// ReplicateImage copies the image to all accessable GCE regions
+func (i *GCEImage) ReplicateImage(makePublic bool) (map[string]Image, error) {
+	if makePublic {
+		return nil, fmt.Errorf("GCE does not currently support public images")
+	}
+
+	images := make(map[string]Image)
+	// All images are already global
+	return images, nil
+}

--- a/imagebuilder/pkg/imagebuilder/ssh.go
+++ b/imagebuilder/pkg/imagebuilder/ssh.go
@@ -1,0 +1,246 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+// TODO: This probably should be moved to / shared with nodeup, because then it would allow action on a remote target
+
+package imagebuilder
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/golang/glog"
+)
+
+// NewSSH constructs a new SSH helper
+func NewSSH(sshClient *ssh.Client) *SSH {
+	return &SSH{
+		sshClient: sshClient,
+	}
+}
+
+// SSH holds an SSH client, and adds utilities like SCP functionality
+type SSH struct {
+	sshClient *ssh.Client
+}
+
+// SCPMkdir executes a mkdir against the SSH target, using SCP
+func (s *SSH) SCPMkdir(dest string, mode os.FileMode) error {
+	glog.Infof("Doing SSH SCP mkdir: %q", dest)
+	session, err := s.sshClient.NewSession()
+	if err != nil {
+		return fmt.Errorf("error establishing SSH session: %v", err)
+	}
+	defer session.Close()
+
+	name := filepath.Base(dest)
+	scpBase := filepath.Dir(dest)
+	//scpBase = "." + scpBase
+
+	var stdinErr error
+	go func() {
+		w, _ := session.StdinPipe()
+		defer w.Close()
+		_, stdinErr = fmt.Fprintln(w, "D0"+toOctal(mode), 0, name)
+		if stdinErr != nil {
+			return
+		}
+	}()
+	output, err := session.CombinedOutput("/usr/bin/scp -tr " + scpBase)
+	if err != nil {
+		glog.Warningf("Error output from SCP: %s", output)
+		return fmt.Errorf("error doing SCP mkdir: %v", err)
+	}
+	if stdinErr != nil {
+		glog.Warningf("Error output from SCP: %s", output)
+		return fmt.Errorf("error doing SCP mkdir (writing to stdin): %v", stdinErr)
+	}
+
+	return nil
+}
+
+func toOctal(mode os.FileMode) string {
+	return strconv.FormatUint(uint64(mode), 8)
+}
+
+// SCPPut copies a file to the SSH target, using SCP
+func (s *SSH) SCPPut(dest string, length int, content io.Reader, mode os.FileMode) error {
+	glog.Infof("Doing SSH SCP upload: %q", dest)
+	session, err := s.sshClient.NewSession()
+	if err != nil {
+		return fmt.Errorf("error establishing SSH session: %v", err)
+	}
+	defer session.Close()
+
+	name := filepath.Base(dest)
+	scpBase := filepath.Dir(dest)
+	//scpBase = "." + scpBase
+
+	var stdinErr error
+	go func() {
+		w, _ := session.StdinPipe()
+		defer w.Close()
+		_, stdinErr = fmt.Fprintln(w, "C0"+toOctal(mode), length, name)
+		if stdinErr != nil {
+			return
+		}
+		_, stdinErr = io.Copy(w, content)
+		if stdinErr != nil {
+			return
+		}
+		_, stdinErr = fmt.Fprint(w, "\x00")
+		if stdinErr != nil {
+			return
+		}
+	}()
+	output, err := session.CombinedOutput("/usr/bin/scp -tr " + scpBase)
+	if err != nil {
+		glog.Warningf("Error output from SCP: %s", output)
+		return fmt.Errorf("error doing SCP put: %v", err)
+	}
+	if stdinErr != nil {
+		glog.Warningf("Error output from SCP: %s", output)
+		return fmt.Errorf("error doing SCP put (writing to stdin): %v", stdinErr)
+	}
+
+	return nil
+}
+
+// CommandExecution helps us build a command for running
+type CommandExecution struct {
+	Command string
+	Cwd     string
+	Env     map[string]string
+	Sudo    bool
+	ssh     *SSH
+}
+
+// WithSudo indicates that the command should be executed with sudo
+func (c *CommandExecution) WithSudo() *CommandExecution {
+	c.Sudo = true
+	return c
+}
+
+// WithCwd sets the directory in which the command will execute
+func (c *CommandExecution) WithCwd(cwd string) *CommandExecution {
+	c.Cwd = cwd
+	return c
+}
+
+// Setenv sets an environment variable for the command execution
+func (c *CommandExecution) Setenv(k, v string) *CommandExecution {
+	c.Env[k] = v
+	return c
+}
+
+// Run executes the command
+func (c *CommandExecution) Run() error {
+	return c.ssh.run(c)
+}
+
+// Command builds a CommandExecution bound to the current SSH target
+func (s *SSH) Command(cmd string) *CommandExecution {
+	c := &CommandExecution{
+		ssh:     s,
+		Command: cmd,
+		Env:     make(map[string]string),
+	}
+	return c
+}
+
+// Exec executes a command against the SSH target
+func (s *SSH) Exec(cmd string) error {
+	c := s.Command(cmd)
+	return c.Run()
+}
+
+// TODO: I bet we could refactor this nicely using a fluent calling style...
+func (s *SSH) run(cmd *CommandExecution) error {
+	// Warn if the caller is doing something dumb
+	if cmd.Sudo && strings.HasPrefix(cmd.Command, "sudo ") {
+		glog.Warningf("sudo used with command that includes sudo (%q)", cmd.Command)
+	}
+
+	var script bytes.Buffer
+
+	needScript := false
+
+	script.WriteString("#!/bin/bash -e\n")
+	if cmd.Cwd != "" {
+		script.WriteString("cd " + cmd.Cwd + "\n")
+		needScript = true
+	}
+	if cmd.Env != nil && len(cmd.Env) != 0 {
+		// Most SSH servers are configured not to accept arbitrary env vars
+		for k, v := range cmd.Env {
+			/*			err := session.Setenv(k, v)
+						if err != nil {
+							return fmt.Errorf("error setting env var in SSH session: %v", err)
+						}
+			*/
+			script.WriteString("export " + k + "='" + v + "'\n")
+			needScript = true
+		}
+	}
+	script.WriteString(cmd.Command + "\n")
+
+	session, err := s.sshClient.NewSession()
+	if err != nil {
+		return fmt.Errorf("error establishing SSH session: %v", err)
+	}
+	defer session.Close()
+
+	cmdToRun := cmd.Command
+	if needScript {
+		tmpScript := fmt.Sprintf("/tmp/ssh-exec-%d", rand.Int63())
+		scriptBytes := script.Bytes()
+		err := s.SCPPut(tmpScript, len(scriptBytes), bytes.NewReader(scriptBytes), 0755)
+		if err != nil {
+			return fmt.Errorf("error uploading temporary script: %v", err)
+		}
+		defer s.Exec("rm -f " + tmpScript)
+		cmdToRun = tmpScript
+		if cmd.Sudo {
+			cmdToRun = "sudo " + cmdToRun
+		}
+	} else {
+		cmdToRun = cmd.Command
+		if cmd.Sudo {
+			cmdToRun = "sudo " + cmdToRun
+		}
+	}
+
+	// We "lie" about the command we're running when we're using a script
+	glog.Infof("Executing SSH command: %q", cmd.Command)
+	output, err := session.CombinedOutput(cmdToRun)
+	if err != nil {
+		glog.Infof("Error from SSH command %q: %v", cmd.Command, err)
+		glog.Infof("Output was: %s", output)
+		return fmt.Errorf("error executing SSH command %q: %v", cmd.Command, err)
+	}
+
+	glog.V(2).Infof("Output was: %s", output)
+	return nil
+}

--- a/imagebuilder/pkg/imagebuilder/template.go
+++ b/imagebuilder/pkg/imagebuilder/template.go
@@ -1,0 +1,31 @@
+package imagebuilder
+
+import (
+	"fmt"
+	"text/template"
+	"bytes"
+)
+
+// ExpandTemplate executes a golang template
+func ExpandTemplate(key string, templateString string, context interface{}) (string, error) {
+	t := template.New(key)
+
+	funcMap := make(template.FuncMap)
+
+	t.Funcs(funcMap)
+
+	_, err := t.Parse(templateString)
+	if err != nil {
+		return "", fmt.Errorf("error parsing template %q: %v", key, err)
+	}
+
+	t.Option("missingkey=zero")
+
+	var buffer bytes.Buffer
+	err = t.ExecuteTemplate(&buffer, key, context)
+	if err != nil {
+		return "", fmt.Errorf("error executing template %q: %v", key, err)
+	}
+
+	return buffer.String(), nil
+}

--- a/imagebuilder/pkg/imagebuilder/utils.go
+++ b/imagebuilder/pkg/imagebuilder/utils.go
@@ -1,0 +1,20 @@
+package imagebuilder
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+	"os"
+)
+
+// ReadFile reads the whole file using ioutil.ReadFile, but does path expansion first
+func ReadFile(p string) ([]byte, error) {
+	if strings.HasPrefix(p, "~/") {
+		p = os.Getenv("HOME") + p[1:]
+	}
+	data, err := ioutil.ReadFile(p)
+	if err != nil {
+		return nil, fmt.Errorf("error reading file %q: %v", p, err)
+	}
+	return data, nil
+}


### PR DESCRIPTION
(A version of) this tool is used to build the AWS image that is currently the default image used in kube-up.  I previously proposed this into kubernetes/contrib as https://github.com/kubernetes/contrib/pull/486, but this seems a better place for it.

I extended the tool to support GCE images also.  We don't currently have a public Debian Jessie image on GCE that has the cgroups memory controller enabled (this was the root problem that required the custom image in the first place on AWS as well).

Most of this PR is code to bring up an instance, from which we can then run the bootstrap-vz tool.  I would like to replace that code with the code that will be in the cloudup tool to bring up clouds.  But - for now - getting cloudup & nodeup depends on a working image, so I think this sequence makes sense...

cc @zmerlynn 
