### PR TITLE
upup: Map GCE image-url to string consistently

### DIFF
--- a/upup/pkg/fi/cloudup/gcetasks/instance_template.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instance_template.go
@@ -60,7 +60,7 @@ func (e *InstanceTemplate) Find(c *fi.Context) (*InstanceTemplate, error) {
 	actual.MachineType = fi.String(lastComponent(p.MachineType))
 	actual.CanIPForward = &p.CanIpForward
 
-	bootDiskImage, err := ShortenImageURL(p.Disks[0].InitializeParams.SourceImage)
+	bootDiskImage, err := ShortenImageURL(cloud.Project, p.Disks[0].InitializeParams.SourceImage)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing source image URL: %v", err)
 	}


### PR DESCRIPTION
We need to reverse our image shortening consistently with how we resolve
the image, so that --dryrun does not report spurious changes.
