### PR TITLE
upup: Make reflective walk more logical, use for dryrun change printing

### DIFF
--- a/upup/pkg/fi/nodeup/build_flags.go
+++ b/upup/pkg/fi/nodeup/build_flags.go
@@ -51,7 +51,7 @@ func buildFlags(options interface{}) (string, error) {
 		}
 		return nil
 	}
-	err := utils.WalkRecursive(reflect.ValueOf(options), walker)
+	err := utils.ReflectRecursive(reflect.ValueOf(options), walker)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Remove a bunch of inconsistencies so that the reflective walk is not
suprising, and also rename it to ReflectRecursive.

Then use this for dry-run change printing.

cc @mikedanese 
