### PR TITLE
upup: Map matching image ids to source name

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/instance.go
+++ b/upup/pkg/fi/cloudup/awstasks/instance.go
@@ -106,6 +106,19 @@ func (e *Instance) Find(c *fi.Context) (*Instance, error) {
 
 	e.ID = actual.ID
 
+	// Avoid spurious changes on ImageId
+	if e.ImageID != nil && actual.ImageID != nil && *actual.ImageID != *e.ImageID {
+		image, err := cloud.ResolveImage(*e.ImageID)
+		if err != nil {
+			glog.Warningf("unable to resolve image: %q: %v", *e.ImageID, err)
+		} else if image == nil {
+			glog.Warningf("unable to resolve image: %q: not found", *e.ImageID)
+		} else if aws.StringValue(image.ImageId) == *actual.ImageID {
+			glog.V(4).Infof("Returning matching ImageId as expected name: %q -> %q", *actual.ImageID, *e.ImageID)
+			actual.ImageID = e.ImageID
+		}
+	}
+
 	return actual, nil
 }
 

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -203,6 +203,7 @@ func (t *AWSCloud) DescribeVPC(vpcID string) (*ec2.Vpc, error) {
 // owner/name in which case we find the image with the specified name, owned by owner
 // name in which case we find the image with the specified name, with the current owner
 func (c *AWSCloud) ResolveImage(name string) (*ec2.Image, error) {
+	// TODO: Cache this result during a single execution (we get called multiple times)
 	glog.V(2).Infof("Calilng DescribeImages to resolve name %q", name)
 	request := &ec2.DescribeImagesInput{}
 


### PR DESCRIPTION
This avoids spurious changes, and also is more intuitive for the user -
whatever name the user gave it, if it resolves to the same image, that
is the name we will use.
