### PR TITLE
create a chroot aci for docker and kubelet

### DIFF
--- a/node-aci/.gitignore
+++ b/node-aci/.gitignore
@@ -1,0 +1,3 @@
+.acbuild
+library-debian-jessie.aci
+node.aci

--- a/node-aci/build
+++ b/node-aci/build
@@ -1,0 +1,39 @@
+#! /bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+set -o xtrace
+
+rm -f node.aci
+
+docker2aci docker://debian:jessie
+
+acbuild begin ./library-debian-jessie.aci
+
+acbuild run -- apt-get update
+acbuild run -- apt-get install -y -q apparmor curl iptables
+acbuild run -- apt-get autoremove
+acbuild run -- apt-get clean
+
+acbuild run -- \
+  curl -sSL --fail \
+    "https://get.docker.com/builds/Linux/x86_64/docker-1.11.1.tgz" \
+    -o /opt/docker.tgz
+acbuild run -- tar xzfv /opt/docker.tgz --strip=1 -C "/usr/local/bin"
+acbuild run -- rm /opt/docker.tgz
+
+acbuild run -- \
+  curl -sSL --fail \
+    "https://storage.googleapis.com/kubernetes-release/release/v1.3.0-alpha.4/bin/linux/amd64/kubectl" \
+    -o "/usr/local/bin/kubectl"
+acbuild run -- chmod +x "/usr/local/bin/kubectl"
+
+acbuild run -- \
+  curl -sSL --fail \
+    "https://storage.googleapis.com/kubernetes-release/release/v1.3.0-alpha.4/bin/linux/amd64/kubelet" \
+    -o "/usr/local/bin/kubelet"
+acbuild run -- chmod +x "/usr/local/bin/kubelet"
+
+acbuild write node.aci
+acbuild end

--- a/node-aci/docker.service
+++ b/node-aci/docker.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Docker Application Container Engine
+Documentation=https://docs.docker.com
+After=network.target
+
+[Service]
+Type=notify
+RootDirectory=/opt/kubelet/rootfs
+ExecStart=/usr/local/bin/docker daemon
+ExecReload=/bin/kill -s HUP $MAINPID
+LimitNOFILE=1048576
+LimitNPROC=1048576
+LimitCORE=infinity
+# Only systemd 226 and above support this version.
+TasksMax=infinity
+TimeoutStartSec=0
+# set delegate yes so that systemd does not reset the cgroups of docker containers
+Delegate=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/node-aci/kubelet.service
+++ b/node-aci/kubelet.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Kubernetes Kubelet Server
+Documentation=https://github.com/kubernetes/kubernetes
+After=network.target docker.socket
+
+[Service]
+RootDirectory=/opt/kubelet/rootfs
+ExecStart=/usr/local/bin/kubelet \
+            --address=0.0.0.0 \
+            --allow-privileged=true \
+            --enable-server \
+            --config=/etc/kubernetes/manifests \
+            --cluster-dns=10.0.0.10 \
+            --cluster-domain=cluster.local \
+            --v=2
+
+[Install]
+WantedBy=multi-user.target

--- a/node-aci/unpack
+++ b/node-aci/unpack
@@ -1,0 +1,31 @@
+#! /bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+ROOTFS=/opt/kubelet/rootfs
+
+mount_in() {
+  local path="${1}"
+  local shared="${2:-false}"
+  mkdir -p "${path}"
+  mkdir -p "${ROOTFS}${path}"
+  mount --rbind "${path}" "${ROOTFS}${path}"
+  if [[ "${shared}" == "true" ]]; then
+    mount --bind "${ROOTFS}${path}" "${ROOTFS}${path}"
+    mount --make-shared "${ROOTFS}${path}"
+  fi
+}
+
+mkdir -p /opt/kubelet
+tar xzvf node.aci -C /opt/kubelet
+
+mount_in /proc
+mount_in /sys
+mount_in /dev
+mount_in /run
+mount_in /var/run
+mount_in /etc
+mount_in /var/lib/docker
+mount_in /var/lib/kubelet true


### PR DESCRIPTION
./unpack creates a chroot with docker and kubelet sutible for using as the RootDirectory (chroot env) for a systemd unit.
