### PR TITLE
Protokube: components through volumes

### DIFF
--- a/protokube/Makefile
+++ b/protokube/Makefile
@@ -1,5 +1,5 @@
 gocode: godeps
-	go install k8s.io/kube-deploy/protokube/cmd/...
+	go install k8s.io/kube-deploy/protokube/cmd/protokube
 
 godeps:
 	# I think strip-vendor is the workaround for 25572
@@ -9,6 +9,8 @@ tar: gocode
 	rm -rf .build/tar
 	mkdir -p .build/tar/protokube/root
 	cp ${GOPATH}/bin/protokube .build/tar/protokube/root
+	cp -r model/ .build/tar/protokube/root/model/
+	cp -r templates/ .build/tar/protokube/root/templates/
 	tar czvf .build/protokube.tar.gz -C .build/tar/ .
 	tar tvf .build/protokube.tar.gz
 	(sha1sum .build/protokube.tar.gz | cut -d' ' -f1) > .build/protokube.tar.gz.sha1
@@ -21,3 +23,23 @@ upload: tar
 	aws s3 sync .build/s3/ s3://kubeupv2/
 	aws s3api put-object-acl --bucket kubeupv2 --key protokube/protokube.tar.gz --acl public-read
 	aws s3api put-object-acl --bucket kubeupv2 --key protokube/protokube.tar.gz.sha1 --acl public-read
+
+ssh-push: tar
+	scp .build/protokube.tar.gz ${TARGET}:/tmp/
+	ssh ${TARGET} sudo tar zxf /tmp/protokube.tar.gz -C /opt/
+
+gofmt:
+	gofmt -w -s cmd/
+	gofmt -w -s pkg/
+
+builder-image:
+	docker build -f images/builder/Dockerfile -t builder .
+
+build-in-docker: builder-image
+	docker run -it -v `pwd`:/src builder /onbuild.sh
+
+image: build-in-docker
+	docker build -t kope/protokube  -f images/protokube/Dockerfile .
+
+push: image
+	docker push kope/protokube:latest

--- a/protokube/cmd/protokube/main.go
+++ b/protokube/cmd/protokube/main.go
@@ -2,30 +2,29 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"github.com/golang/glog"
 	"k8s.io/kube-deploy/protokube/pkg/protokube"
+	"net"
 	"os"
+	"strings"
 )
 
 func main() {
-	//flagModel := "model"
-	//flag.StringVar(&flagModel, "model", flagModel, "directory to use as model for desired configuration")
-	//var flagConf string
-	//flag.StringVar(&flagConf, "conf", "node.yaml", "configuration location")
-	//var flagAssetDir string
-	//flag.StringVar(&flagAssetDir, "assets", "/var/cache/nodeup", "the location for the local asset cache")
-	//
-	//dryrun := false
-	//flag.BoolVar(&dryrun, "dryrun", false, "Don't create cloud resources; just show what would be done")
-	//target := "direct"
-	//flag.StringVar(&target, "target", target, "Target - direct, cloudinit")
-
-	//if dryrun {
-	//	target = "dryrun"
-	//}
-
 	master := false
-	flag.BoolVar(&master, "master", false, "Act as master")
+	flag.BoolVar(&master, "master", master, "Act as master")
+
+	containerized := false
+	flag.BoolVar(&containerized, "containerized", containerized, "Set if we are running containerized.")
+
+	dnsZoneName := ""
+	flag.StringVar(&dnsZoneName, "dns-zone-name", dnsZoneName, "Name of zone to use for DNS")
+
+	dnsInternalSuffix := ""
+	flag.StringVar(&dnsInternalSuffix, "dns-internal-suffix", dnsInternalSuffix, "DNS suffix for internal domain names")
+
+	clusterID := ""
+	flag.StringVar(&clusterID, "cluster-id", clusterID, "Cluster ID")
 
 	flag.Set("logtostderr", "true")
 	flag.Parse()
@@ -36,20 +35,80 @@ func main() {
 		os.Exit(1)
 	}
 
-	//if flagConf == "" {
-	//	glog.Exitf("--conf is required")
-	//}
+	if clusterID == "" {
+		clusterID = volumes.ClusterID()
+		if clusterID == "" {
+			glog.Errorf("cluster-id is required (cannot be determined from cloud)")
+			os.Exit(1)
+		} else {
+			glog.Infof("Setting cluster-id from cloud: %s", clusterID)
+		}
+	}
 
-	kubeboot := protokube.NewKubeBoot(master, volumes)
-	err = kubeboot.Bootstrap()
+	if dnsInternalSuffix == "" {
+		// TODO: Maybe only master needs DNS?
+		dnsInternalSuffix = ".internal." + clusterID
+		glog.Infof("Setting dns-internal-suffix to %q", dnsInternalSuffix)
+	}
+
+	// Make sure it's actually a suffix (starts with .)
+	if !strings.HasPrefix(dnsInternalSuffix, ".") {
+		dnsInternalSuffix = "." + dnsInternalSuffix
+	}
+
+	if dnsZoneName == "" {
+		tokens := strings.Split(dnsInternalSuffix, ".")
+		dnsZoneName = strings.Join(tokens[len(tokens)-2:], ".")
+	}
+
+	// Get internal IP from cloud, to avoid problems if we're in a container
+	// TODO: Just run with --net=host ??
+	//internalIP, err := findInternalIP()
+	//if err != nil {
+	//	glog.Errorf("Error finding internal IP: %q", err)
+	//	os.Exit(1)
+	//}
+	internalIP := volumes.InternalIP()
+
+	dns, err := protokube.NewRoute53DNSProvider(dnsZoneName)
+	if err != nil {
+		glog.Errorf("Error initializing DNS: %q", err)
+		os.Exit(1)
+	}
+
+	rootfs := "/"
+	if containerized {
+		rootfs = "/rootfs/"
+	}
+	k := &protokube.KubeBoot{
+		Containerized: containerized,
+		RootFS:        rootfs,
+
+		Master:            master,
+		InternalDNSSuffix: dnsInternalSuffix,
+		InternalIP:        internalIP,
+		//MasterID          : fromVolume
+		//EtcdClusters   : fromVolume
+
+		Volumes: volumes,
+		DNS:     dns,
+	}
+
+	err = k.Bootstrap()
 	if err != nil {
 		glog.Errorf("Error during bootstrap: %q", err)
 		os.Exit(1)
 	}
 
-	glog.Infof("Bootstrap complete; starting kubelet")
+	glog.Infof("Bootstrap complete; applying configuration")
+	err = k.ApplyModel()
+	if err != nil {
+		glog.Errorf("Error during configuration: %q", err)
+		os.Exit(1)
+	}
 
-	err = kubeboot.RunBootstrapTasks()
+	glog.Infof("Bootstrap complete; starting kubelet")
+	err = k.RunBootstrapTasks()
 	if err != nil {
 		glog.Errorf("Error during bootstrap: %q", err)
 		os.Exit(1)
@@ -57,4 +116,67 @@ func main() {
 
 	glog.Infof("Unexpected exited from kubelet run")
 	os.Exit(1)
+}
+
+// TODO: run with --net=host ??
+func findInternalIP() (net.IP, error) {
+	var ips []net.IP
+
+	networkInterfaces, err := net.Interfaces()
+	if err != nil {
+		return nil, fmt.Errorf("error querying interfaces to determine internal ip: %v", err)
+	}
+
+	for i := range networkInterfaces {
+		networkInterface := &networkInterfaces[i]
+		flags := networkInterface.Flags
+		name := networkInterface.Name
+
+		if (flags & net.FlagLoopback) != 0 {
+			glog.V(2).Infof("Ignoring interface %s - loopback", name)
+			continue
+		}
+
+		// Not a lot else to go on...
+		if !strings.HasPrefix(name, "eth") {
+			glog.V(2).Infof("Ignoring interface %s - name does not look like ethernet device", name)
+			continue
+		}
+
+		addrs, err := networkInterface.Addrs()
+		if err != nil {
+			return nil, fmt.Errorf("error querying network interface %s for IP adddresses: %v", name, err)
+		}
+
+		for _, addr := range addrs {
+			ip, _, err := net.ParseCIDR(addr.String())
+			if err != nil {
+				return nil, fmt.Errorf("error parsing address %s on network interface %s: %v", addr.String(), name, err)
+			}
+
+			if ip.IsLoopback() {
+				glog.V(2).Infof("Ignoring address %s (loopback)", ip)
+				continue
+			}
+
+			if ip.IsLinkLocalMulticast() || ip.IsLinkLocalUnicast() {
+				glog.V(2).Infof("Ignoring address %s (link-local)", ip)
+				continue
+			}
+
+			ips = append(ips, ip)
+		}
+	}
+
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("unable to determine internal ip (no adddresses found)")
+	}
+
+	if len(ips) != 1 {
+		glog.Warningf("Found multiple internal IPs; making arbitrary choice")
+		for _, ip := range ips {
+			glog.Warningf("\tip: %s", ip.String())
+		}
+	}
+	return ips[0], nil
 }

--- a/protokube/glide.lock
+++ b/protokube/glide.lock
@@ -1,5 +1,5 @@
-hash: d51b01457dd5499bc488e3a367f00fd9e935cdf125296e9451bbf39458fe255a
-updated: 2016-05-29T08:36:17.761287445-04:00
+hash: 212c116624840fbcaaf42e4f11b9f159e3426b8dffbb8b7747a1615ea68e7fb5
+updated: 2016-06-05T15:03:24.971484029-04:00
 imports:
 - name: github.com/aws/aws-sdk-go
   version: c924893c38ecc04b18d7aab8a7aa561cb8b4c4cc
@@ -9,6 +9,7 @@ imports:
   - aws/request
   - aws/session
   - service/ec2
+  - service/route53
   - aws/awserr
   - aws/credentials
   - aws/client
@@ -21,10 +22,16 @@ imports:
   - private/protocol/ec2query
   - private/signer/v4
   - private/waiter
+  - private/protocol/restxml
   - aws/credentials/ec2rolecreds
   - private/protocol/query/queryutil
   - private/protocol/xml/xmlutil
   - private/protocol/rest
+  - private/protocol/query
+- name: github.com/cloudfoundry-incubator/candiedyaml
+  version: 99c3df83b51532e3615f851d8c2dbb638f5313bf
+- name: github.com/ghodss/yaml
+  version: aa0c862057666179de291b67d9f093d12b5a8473
 - name: github.com/go-ini/ini
   version: 2e44421e256d82ebbf3d4d4fcabe8930b905eff3
 - name: github.com/golang/glog
@@ -32,7 +39,7 @@ imports:
 - name: github.com/jmespath/go-jmespath
   version: 3433f3ea46d9f8019119e7dd41274e112a2359a9
 - name: k8s.io/kubernetes
-  version: a99e4ca79334cefd5fbdd0fd7f78a6b2595f2fde
+  version: 56af9acd6f0a36f974fe8a9d0bd06049b14d5d19
   subpackages:
   - pkg/util/exec
   - pkg/util/mount

--- a/protokube/glide.yaml
+++ b/protokube/glide.yaml
@@ -12,3 +12,4 @@ import:
   subpackages:
   - pkg/util/exec
   - pkg/util/mount
+- package: github.com/ghodss/yaml

--- a/protokube/images/builder/Dockerfile
+++ b/protokube/images/builder/Dockerfile
@@ -1,0 +1,14 @@
+FROM debian:jessie
+
+# Install packages:
+#  curl (to download glide & golang)
+#  git, mercurial (for go get)
+RUN apt-get update && apt-get install --yes curl mercurial git gcc make
+
+# Install golang
+RUN curl -L https://storage.googleapis.com/golang/go1.6.2.linux-amd64.tar.gz | tar zx -C /usr/local
+ENV PATH $PATH:/usr/local/go/bin
+# Install glide
+RUN curl -L https://github.com/Masterminds/glide/releases/download/0.10.2/glide-0.10.2-linux-amd64.tar.gz | tar zx --strip-components 1 -C /usr/bin
+
+COPY images/builder/onbuild.sh /onbuild.sh

--- a/protokube/images/builder/onbuild.sh
+++ b/protokube/images/builder/onbuild.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+mkdir -p /go
+export GOPATH=/go
+
+mkdir -p /go/src/k8s.io/kube-deploy
+ln -s /src/ /go/src/k8s.io/kube-deploy/protokube
+
+ls -lR  /go/src/k8s.io/kube-deploy/protokube/cmd/
+
+cd /go/src/k8s.io/kube-deploy/protokube/
+make gocode
+
+mkdir -p /src/.build/artifacts/
+cp /go/bin/protokube /src/.build/artifacts/

--- a/protokube/images/protokube/Dockerfile
+++ b/protokube/images/protokube/Dockerfile
@@ -1,0 +1,12 @@
+FROM debian:jessie
+
+# ca-certificates: Needed to talk to EC2 API
+# e2fsprogs: Needed to mount / format ext4 filesytems
+RUN apt-get update && apt-get install --yes ca-certificates e2fsprogs
+
+COPY model/ /model/
+COPY templates/ /templates/
+COPY /.build/artifacts/protokube /usr/bin/protokube
+
+CMD /usr/bin/protokube
+

--- a/protokube/model/etcd/events.config
+++ b/protokube/model/etcd/events.config
@@ -1,0 +1,5 @@
+ClusterName: etcd-events
+ClientPort: 4002
+PeerPort: 2381
+DataDirName: data-events
+PodName: etcd-server-events

--- a/protokube/model/etcd/main.config
+++ b/protokube/model/etcd/main.config
@@ -1,0 +1,5 @@
+ClusterName: etcd
+ClientPort: 4001
+PeerPort: 2380
+DataDirName: data
+PodName: etcd-server

--- a/protokube/pkg/protokube/aws_dns.go
+++ b/protokube/pkg/protokube/aws_dns.go
@@ -1,0 +1,117 @@
+package protokube
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/golang/glog"
+	"strings"
+	"time"
+)
+
+type Route53DNSProvider struct {
+	client *route53.Route53
+
+	zoneName string
+	zone     *route53.HostedZone
+}
+
+func NewRoute53DNSProvider(zoneName string) (*Route53DNSProvider, error) {
+	if zoneName == "" {
+		return nil, fmt.Errorf("zone name is required")
+	}
+
+	p := &Route53DNSProvider{
+		zoneName: zoneName,
+	}
+
+	s := session.New()
+	s.Handlers.Send.PushFront(func(r *request.Request) {
+		// Log requests
+		glog.V(4).Infof("AWS API Request: %s/%s", r.ClientInfo.ServiceName, r.Operation.Name)
+	})
+
+	config := aws.NewConfig()
+
+	p.client = route53.New(s, config)
+
+	return p, nil
+}
+
+func (p *Route53DNSProvider) getZone() (*route53.HostedZone, error) {
+	if p.zone != nil {
+		return p.zone, nil
+	}
+
+	findZone := p.zoneName
+	if !strings.HasSuffix(findZone, ".") {
+		findZone += "."
+	}
+	request := &route53.ListHostedZonesByNameInput{
+		DNSName: aws.String(findZone),
+	}
+
+	response, err := p.client.ListHostedZonesByName(request)
+	if err != nil {
+		return nil, fmt.Errorf("error querying for DNS HostedZones %q: %v", findZone, err)
+	}
+
+	var zones []*route53.HostedZone
+	for _, zone := range response.HostedZones {
+		if aws.StringValue(zone.Name) == findZone {
+			zones = append(zones, zone)
+		}
+	}
+	if len(zones) == 0 {
+		return nil, nil
+	}
+	if len(zones) != 1 {
+		return nil, fmt.Errorf("found multiple hosted zones matched name %q", findZone)
+	}
+
+	p.zone = zones[0]
+
+	return p.zone, nil
+}
+
+func (p *Route53DNSProvider) Set(fqdn string, recordType string, value string, ttl time.Duration) error {
+	zone, err := p.getZone()
+	if err != nil {
+		return err
+	}
+
+	rrs := &route53.ResourceRecordSet{
+		Name: aws.String(fqdn),
+		Type: aws.String(recordType),
+		TTL:  aws.Int64(int64(ttl.Seconds())),
+		ResourceRecords: []*route53.ResourceRecord{
+			{Value: aws.String(value)},
+		},
+	}
+
+	change := &route53.Change{
+		Action:            aws.String("UPSERT"),
+		ResourceRecordSet: rrs,
+	}
+
+	changeBatch := &route53.ChangeBatch{}
+	changeBatch.Changes = []*route53.Change{change}
+
+	request := &route53.ChangeResourceRecordSetsInput{}
+	request.HostedZoneId = zone.Id
+	request.ChangeBatch = changeBatch
+
+	glog.V(2).Infof("Updating DNS record %q", fqdn)
+	glog.V(4).Infof("route53 request: %s", DebugString(request))
+
+	response, err := p.client.ChangeResourceRecordSets(request)
+	if err != nil {
+		return fmt.Errorf("error creating ResourceRecordSets: %v", err)
+	}
+
+	glog.V(2).Infof("Change id is %q", aws.StringValue(response.ChangeInfo.Id))
+
+	return nil
+}

--- a/protokube/pkg/protokube/etcd_cluster.go
+++ b/protokube/pkg/protokube/etcd_cluster.go
@@ -1,0 +1,153 @@
+package protokube
+
+import (
+	"fmt"
+	"github.com/ghodss/yaml"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+)
+
+type EtcdCluster struct {
+	PeerPort     int
+	ClientPort   int
+	LogFile      string
+	DataDirName  string
+	ClusterName  string
+	ClusterToken string
+	Me           *EtcdNode
+	Nodes        []*EtcdNode
+	PodName      string
+
+	Spec *EtcdClusterSpec
+}
+
+func (e *EtcdCluster) String() string {
+	return DebugString(e)
+}
+
+type EtcdNode struct {
+	Name         string
+	InternalName string
+}
+
+func (e *EtcdNode) String() string {
+	return DebugString(e)
+}
+
+func (k *KubeBoot) BuildEtcdClusters(modelDir string) ([]*EtcdCluster, error) {
+	var clusters []*EtcdCluster
+
+	for _, spec := range k.EtcdClusters {
+		modelTemplatePath := path.Join(modelDir, spec.ClusterKey+".config")
+		modelTemplate, err := ioutil.ReadFile(modelTemplatePath)
+		if err != nil {
+			return nil, fmt.Errorf("error reading model template %q: %v", modelTemplatePath, err)
+		}
+
+		cluster := &EtcdCluster{}
+		cluster.Spec = spec
+
+		model, err := ExecuteTemplate("model-etcd-"+spec.ClusterKey, string(modelTemplate), cluster)
+		if err != nil {
+			return nil, fmt.Errorf("error executing etcd model template %q: %v", modelTemplatePath, err)
+		}
+
+		err = yaml.Unmarshal([]byte(model), cluster)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing etcd model template %q: %v", modelTemplatePath, err)
+		}
+
+		clusters = append(clusters, cluster)
+	}
+
+	return clusters, nil
+}
+
+func (c *EtcdCluster) configure(k *KubeBoot) error {
+	name := c.ClusterName
+	if !strings.HasPrefix(name, "etcd") {
+		// For sanity, and to avoid collisions in directories / dns
+		return fmt.Errorf("unexpected name for etcd cluster (must start with etcd): %q", name)
+	}
+	if c.LogFile == "" {
+		c.LogFile = "/var/log/" + name + ".log"
+	}
+
+	if c.PodName == "" {
+		c.PodName = c.ClusterName
+	}
+
+	err := touchFile(k.PathFor(c.LogFile))
+	if err != nil {
+		return fmt.Errorf("error touching log-file %q: %v", c.LogFile, err)
+	}
+
+	if c.ClusterToken == "" {
+		c.ClusterToken = "etcd-cluster-token-" + name
+	}
+
+	for _, nodeName := range c.Spec.NodeNames {
+		name := name + "-" + nodeName
+		fqdn := k.BuildInternalDNSName(name)
+
+		node := &EtcdNode{
+			Name:         name,
+			InternalName: fqdn,
+		}
+		c.Nodes = append(c.Nodes, node)
+
+		if nodeName == c.Spec.NodeName {
+			c.Me = node
+
+			err := k.MapInternalDNSName(fqdn)
+			if err != nil {
+				return fmt.Errorf("error mapping internal dns name for %q: %v", name, err)
+			}
+		}
+	}
+
+	if c.Me == nil {
+		return fmt.Errorf("my node name %s not found in cluster %v", c.Spec.NodeName, strings.Join(c.Spec.NodeNames, ","))
+	}
+
+	manifestTemplatePath := "templates/etcd/manifest.template"
+	manifestTemplate, err := ioutil.ReadFile(manifestTemplatePath)
+	if err != nil {
+		return fmt.Errorf("error reading etcd manifest template %q: %v", manifestTemplatePath, err)
+	}
+	manifest, err := ExecuteTemplate("etcd-manifest", string(manifestTemplate), c)
+	if err != nil {
+		return fmt.Errorf("error executing etcd manifest template: %v", err)
+	}
+
+	manifestPath := "/etc/kubernetes/manifests/" + name + ".manifest"
+	err = ioutil.WriteFile(k.PathFor(manifestPath), []byte(manifest), 0644)
+	if err != nil {
+		return fmt.Errorf("error writing etcd manifest %q: %v", manifestPath, err)
+	}
+
+	return nil
+}
+
+func touchFile(p string) error {
+	_, err := os.Lstat(p)
+	if err == nil {
+		return nil
+	}
+
+	if !os.IsNotExist(err) {
+		return fmt.Errorf("error getting state of file %q: %v", p, err)
+	}
+
+	f, err := os.Create(p)
+	if err != nil {
+		return fmt.Errorf("error touching file %q: %v", p, err)
+	}
+	err = f.Close()
+	if err != nil {
+		return fmt.Errorf("error closing touched file %q: %v", p, err)
+	}
+	return nil
+}

--- a/protokube/pkg/protokube/kube_boot.go
+++ b/protokube/pkg/protokube/kube_boot.go
@@ -2,20 +2,33 @@ package protokube
 
 import (
 	"github.com/golang/glog"
+	"net"
 	"time"
 )
 
 type KubeBoot struct {
-	master bool
-	volumes Volumes
+	Containerized bool
+	RootFS        string
+
+	Master            bool
+	InternalDNSSuffix string
+	InternalIP        net.IP
+	MasterID          int
+	EtcdClusters      []*EtcdClusterSpec
+
+	Volumes Volumes
+	DNS     DNSProvider
 }
 
-func NewKubeBoot(master bool, volumes Volumes) *KubeBoot {
-	k := &KubeBoot{
-		master: master,
-		volumes: volumes,
+func (k *KubeBoot) PathFor(hostPath string) string {
+	if hostPath[0] != '/' {
+		glog.Fatalf("path was not absolute: %q", hostPath)
 	}
-	return k
+	return k.RootFS + hostPath[1:]
+}
+
+func (k *KubeBoot) String() string {
+	return DebugString(k)
 }
 
 func (k *KubeBoot) Bootstrap() error {
@@ -36,8 +49,8 @@ func (k *KubeBoot) Bootstrap() error {
 }
 
 func (k *KubeBoot) tryBootstrap() (bool, error) {
-	if k.master {
-		mountpoint, err := k.mountMasterVolume()
+	if k.Master {
+		volumeInfo, mountpoint, err := k.mountMasterVolume()
 		if err != nil {
 			return false, err
 		}
@@ -47,7 +60,16 @@ func (k *KubeBoot) tryBootstrap() (bool, error) {
 			return false, nil
 		}
 
-		glog.Infof("mounted master on %s", mountpoint)
+		glog.Infof("mounted master volume %q on %s", volumeInfo.Name, mountpoint)
+
+		// Copy roles from volume
+		k.EtcdClusters = volumeInfo.EtcdClusters
+		for _, etcdClusterSpec := range volumeInfo.EtcdClusters {
+			glog.Infof("Found etcd cluster spec on volume: %v", etcdClusterSpec)
+		}
+
+		k.MasterID = volumeInfo.MasterID
+
 		// TODO: Should we set up symlinks here?
 	}
 

--- a/protokube/pkg/protokube/kube_dns.go
+++ b/protokube/pkg/protokube/kube_dns.go
@@ -1,0 +1,27 @@
+package protokube
+
+import (
+	"fmt"
+	"time"
+)
+
+const defaultTTL = time.Minute
+
+type DNSProvider interface {
+	Set(fqdn string, recordType string, value string, ttl time.Duration) error
+}
+
+// MapInternalName maps a FQDN to the internal IP address of the current machine
+func (k *KubeBoot) MapInternalDNSName(fqdn string) error {
+	err := k.DNS.Set(fqdn, "A", k.InternalIP.String(), defaultTTL)
+	if err != nil {
+		return fmt.Errorf("error configuring DNS name %q: %v", fqdn, err)
+	}
+	return nil
+}
+
+// BuildInternalDNSName builds a DNS name for use inside the cluster, adding our internal DNS suffix to the key,
+func (k *KubeBoot) BuildInternalDNSName(key string) string {
+	fqdn := key + k.InternalDNSSuffix
+	return fqdn
+}

--- a/protokube/pkg/protokube/kube_model.go
+++ b/protokube/pkg/protokube/kube_model.go
@@ -1,0 +1,26 @@
+package protokube
+
+import (
+	"fmt"
+	"github.com/golang/glog"
+)
+
+// ApplyModel applies the configuration as specified in the model
+func (k *KubeBoot) ApplyModel() error {
+	modelDir := "model/etcd"
+
+	etcdClusters, err := k.BuildEtcdClusters(modelDir)
+	if err != nil {
+		return fmt.Errorf("error building etcd models: %v", err)
+	}
+
+	for _, etcdCluster := range etcdClusters {
+		glog.Infof("configuring etcd cluster %s", etcdCluster.ClusterName)
+		err := etcdCluster.configure(k)
+		if err != nil {
+			return fmt.Errorf("error applying etcd model: %v", err)
+		}
+	}
+
+	return nil
+}

--- a/protokube/pkg/protokube/models.go
+++ b/protokube/pkg/protokube/models.go
@@ -1,0 +1,29 @@
+package protokube
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+)
+
+func ExecuteTemplate(key string, contents string, model interface{}) (string, error) {
+	t := template.New(key)
+
+	//funcMap := make(template.FuncMap)
+	//t.Funcs(funcMap)
+
+	_, err := t.Parse(contents)
+	if err != nil {
+		return "", fmt.Errorf("error parsing template %q: %v", key, err)
+	}
+
+	t.Option("missingkey=zero")
+
+	var buffer bytes.Buffer
+	err = t.ExecuteTemplate(&buffer, key, model)
+	if err != nil {
+		return "", fmt.Errorf("error executing template %q: %v", key, err)
+	}
+
+	return buffer.String(), nil
+}

--- a/protokube/pkg/protokube/utils.go
+++ b/protokube/pkg/protokube/utils.go
@@ -1,0 +1,14 @@
+package protokube
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func DebugString(o interface{}) string {
+	b, err := json.Marshal(o)
+	if err != nil {
+		return fmt.Sprintf("error marshaling %T: %v", o, err)
+	}
+	return string(b)
+}

--- a/protokube/pkg/protokube/volumes.go
+++ b/protokube/pkg/protokube/volumes.go
@@ -1,5 +1,10 @@
 package protokube
 
+import (
+	"fmt"
+	"strings"
+)
+
 type Volumes interface {
 	AttachVolume(volume *Volume) (string, error)
 	FindMountedVolumes() ([]*Volume, error)
@@ -10,4 +15,63 @@ type Volume struct {
 	Name      string
 	Device    string
 	Available bool
+
+	Info VolumeInfo
+}
+
+func (v *Volume) String() string {
+	return DebugString(v)
+}
+
+type VolumeInfo struct {
+	Name     string
+	MasterID int
+	// TODO: Maybe the events cluster can just be a PetSet - do we need it for boot?
+	EtcdClusters []*EtcdClusterSpec
+}
+
+func (v *VolumeInfo) String() string {
+	return DebugString(v)
+}
+
+type EtcdClusterSpec struct {
+	ClusterKey string
+
+	NodeName  string
+	NodeNames []string
+}
+
+func (e *EtcdClusterSpec) String() string {
+	return DebugString(e)
+}
+
+// Parses a tag on a volume that encodes an etcd cluster role
+// The format is "<myname>/<allnames>", e.g. "node1/node1,node2,node3"
+func ParseEtcdClusterSpec(clusterKey, v string) (*EtcdClusterSpec, error) {
+	v = strings.TrimSpace(v)
+
+	tokens := strings.Split(v, "/")
+	if len(tokens) != 2 {
+		return nil, fmt.Errorf("invalid EtcdClusterSpec (expected two tokens): %q", v)
+	}
+
+	nodeName := tokens[0]
+	nodeNames := strings.Split(tokens[1], ",")
+
+	found := false
+	for _, s := range nodeNames {
+		if s == nodeName {
+			found = true
+		}
+	}
+	if !found {
+		return nil, fmt.Errorf("invalid EtcdClusterSpec (member not found in all nodes): %q", v)
+	}
+
+	c := &EtcdClusterSpec{
+		ClusterKey: clusterKey,
+		NodeName:   nodeName,
+		NodeNames:  nodeNames,
+	}
+	return c, nil
 }

--- a/protokube/templates/etcd/manifest.template
+++ b/protokube/templates/etcd/manifest.template
@@ -1,0 +1,69 @@
+# etcd podspec
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ .PodName }}
+  namespace: kube-system
+spec:
+  hostNetwork: true
+  containers:
+  - name: etcd-container
+    image: gcr.io/google_containers/etcd:2.2.1
+    resources:
+      requests:
+        cpu: 200m
+    command:
+    - /bin/sh
+    - -c
+    - /usr/local/bin/etcd 1>>/var/log/etcd.log 2>&1
+    env:
+    - name: ETCD_NAME
+      value: {{ .Me.Name }}
+    - name: ETCD_DATA_DIR
+      value: /var/etcd/{{ .DataDirName}}
+    - name: ETCD_LISTEN_PEER_URLS
+      value: http://0.0.0.0:{{ .PeerPort }}
+    - name: ETCD_LISTEN_CLIENT_URLS
+      value: http://0.0.0.0:{{ .ClientPort }}
+    - name: ETCD_ADVERTISE_CLIENT_URLS
+      value: http://{{ .Me.InternalName }}:{{ .ClientPort }}
+    - name: ETCD_INITIAL_ADVERTISE_PEER_URLS
+      value: http://{{ .Me.InternalName }}:{{ .PeerPort }}
+    - name: ETCD_INITIAL_CLUSTER_STATE
+      value: new
+    - name: ETCD_INITIAL_CLUSTER_TOKEN
+      value: {{ .ClusterToken }}
+    - name: ETCD_INITIAL_CLUSTER
+      value: {{ range $index, $node := .Nodes -}}
+             {{- if $index }},{{ end -}}
+             {{ $node.Name }}=http://{{ $node.InternalName }}:{{ $.PeerPort }}
+             {{- end }}
+    livenessProbe:
+      httpGet:
+        host: 127.0.0.1
+        port: {{ .ClientPort }}
+        path: /health
+      initialDelaySeconds: 15
+      timeoutSeconds: 15
+    ports:
+    - name: serverport
+      containerPort: {{ .PeerPort }}
+      hostPort: {{ .PeerPort }}
+    - name: clientport
+      containerPort: {{ .ClientPort }}
+      hostPort: {{ .ClientPort }}
+    volumeMounts:
+    - mountPath: /var/etcd
+      name: varetcd
+      readOnly: false
+    - mountPath: /var/log/etcd.log
+      name: varlogetcd
+      readOnly: false
+  volumes:
+  - name: varetcd
+    hostPath:
+      path: /mnt/master-pd/var/{{ .DataDirName }}
+  - name: varlogetcd
+    hostPath:
+      path: {{ .LogFile }}
+


### PR DESCRIPTION
We can now look at volume tags and create manifests in /etc/kubernetes/manifests based on those tags./

Also support for running in a container.
