### PR TITLE
Add experimental-flannel-overlay flag

### DIFF
--- a/docker-multinode/master.sh
+++ b/docker-multinode/master.sh
@@ -30,13 +30,7 @@ kube::multinode::detect_lsb
 
 kube::multinode::turndown
 
-kube::multinode::bootstrap_daemon
-
 kube::multinode::start_etcd
-
-kube::multinode::start_flannel
-
-kube::multinode::restart_docker
 
 kube::multinode::start_k8s_master
 

--- a/docker-multinode/worker.sh
+++ b/docker-multinode/worker.sh
@@ -31,12 +31,6 @@ kube::multinode::detect_lsb
 
 kube::multinode::turndown
 
-kube::multinode::bootstrap_daemon
-
-kube::multinode::start_flannel
-
-kube::multinode::restart_docker
-
 kube::multinode::start_k8s_worker
 
 kube::multinode::start_k8s_worker_proxy


### PR DESCRIPTION
This PR is some kind of proof of concept for experimental-flannel-overlay flag. Because it is not well documented yet I was experimenting with this. I've removed docker "bootstrap" service and flannel. What I've seen from logs it uses `hairpin` plugin with `hairpin-veth` mode. I've executed e2e test with different hyperkube versions

v1.2.0

```
Ran 94 of 293 Specs in 14982.578 seconds
FAIL! -- 59 Passed | 35 Failed | 0 Pending | 199 Skipped 
```

v1.2.4

```
Ran 94 of 293 Specs in 4962.784 seconds
FAIL! -- 59 Passed | 32 Failed | 0 Pending | 199 Skipped 
```

v1.3.0.alpha5

```
Ran 94 of 293 Specs in 591.524 seconds
FAIL! -- 81 Passed | 13 Failed | 0 Pending | 199 Skipped
```

I hope it will open discussion about networking in docker-multinode project.
