### PR TITLE
upup: prevent spurious changes on tags & names

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -127,6 +127,7 @@ func (e *AutoscalingGroup) Find(c *fi.Context) (*AutoscalingGroup, error) {
 }
 
 func (e *AutoscalingGroup) Run(c *fi.Context) error {
+	c.Cloud.(*awsup.AWSCloud).AddTags(e.Name, e.Tags)
 	return fi.DefaultDeltaRunMethod(e, c)
 }
 
@@ -141,9 +142,6 @@ func (s *AutoscalingGroup) CheckChanges(a, e, changes *AutoscalingGroup) error {
 
 func (e *AutoscalingGroup) buildTags(cloud fi.Cloud) map[string]string {
 	tags := make(map[string]string)
-	for k, v := range cloud.(*awsup.AWSCloud).BuildTags(e.Name, nil) {
-		tags[k] = v
-	}
 	for k, v := range e.Tags {
 		tags[k] = v
 	}

--- a/upup/pkg/fi/cloudup/awstasks/dhcp_options.go
+++ b/upup/pkg/fi/cloudup/awstasks/dhcp_options.go
@@ -135,7 +135,7 @@ func (_ *DHCPOptions) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *DHCPOption
 		e.ID = response.DhcpOptions.DhcpOptionsId
 	}
 
-	return t.AddAWSTags(*e.ID, t.Cloud.BuildTags(e.Name, nil))
+	return t.AddAWSTags(*e.ID, t.Cloud.BuildTags(e.Name))
 }
 
 type terraformDHCPOptions struct {
@@ -149,7 +149,7 @@ func (_ *DHCPOptions) RenderTerraform(t *terraform.TerraformTarget, a, e, change
 
 	tf := &terraformDHCPOptions{
 		DomainName: e.DomainName,
-		Tags:       cloud.BuildTags(e.Name, nil),
+		Tags:       cloud.BuildTags(e.Name),
 	}
 
 	if e.DomainNameServers != nil {

--- a/upup/pkg/fi/cloudup/awstasks/ebsvolume.go
+++ b/upup/pkg/fi/cloudup/awstasks/ebsvolume.go
@@ -85,6 +85,7 @@ func (e *EBSVolume) find(cloud *awsup.AWSCloud) (*EBSVolume, error) {
 }
 
 func (e *EBSVolume) Run(c *fi.Context) error {
+	c.Cloud.(*awsup.AWSCloud).AddTags(e.Name, e.Tags)
 	return fi.DefaultDeltaRunMethod(e, c)
 }
 
@@ -120,7 +121,7 @@ func (_ *EBSVolume) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *EBSVolume) e
 		e.ID = response.VolumeId
 	}
 
-	return t.AddAWSTags(*e.ID, t.Cloud.BuildTags(e.Name, e.Tags))
+	return t.AddAWSTags(*e.ID, e.Tags)
 }
 
 type terraformVolume struct {
@@ -131,13 +132,11 @@ type terraformVolume struct {
 }
 
 func (_ *EBSVolume) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *EBSVolume) error {
-	cloud := t.Cloud.(*awsup.AWSCloud)
-
 	tf := &terraformVolume{
 		AvailabilityZone: e.AvailabilityZone,
 		Size:             e.SizeGB,
 		Type:             e.VolumeType,
-		Tags:             cloud.BuildTags(e.Name, e.Tags),
+		Tags:             e.Tags,
 	}
 
 	return t.RenderResource("aws_ebs_volume", *e.Name, tf)

--- a/upup/pkg/fi/cloudup/awstasks/instance.go
+++ b/upup/pkg/fi/cloudup/awstasks/instance.go
@@ -164,6 +164,7 @@ func nameFromIAMARN(arn *string) *string {
 }
 
 func (e *Instance) Run(c *fi.Context) error {
+	c.Cloud.(*awsup.AWSCloud).AddTags(e.Name, e.Tags)
 	return fi.DefaultDeltaRunMethod(e, c)
 }
 
@@ -250,7 +251,7 @@ func (_ *Instance) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Instance) err
 		e.ID = response.Instances[0].InstanceId
 	}
 
-	return t.AddAWSTags(*e.ID, t.Cloud.BuildTags(e.Name, e.Tags))
+	return t.AddAWSTags(*e.ID, e.Tags)
 }
 
 func (e *Instance) TerraformLink() *terraform.Literal {

--- a/upup/pkg/fi/cloudup/awstasks/internetgateway.go
+++ b/upup/pkg/fi/cloudup/awstasks/internetgateway.go
@@ -80,7 +80,7 @@ func (_ *InternetGateway) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Intern
 		e.ID = response.InternetGateway.InternetGatewayId
 	}
 
-	return t.AddAWSTags(*e.ID, t.Cloud.BuildTags(e.Name, nil))
+	return t.AddAWSTags(*e.ID, t.Cloud.BuildTags(e.Name))
 }
 
 func (_ *InternetGateway) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *InternetGateway) error {

--- a/upup/pkg/fi/cloudup/awstasks/internetgatewayattachment.go
+++ b/upup/pkg/fi/cloudup/awstasks/internetgatewayattachment.go
@@ -109,7 +109,7 @@ func (_ *InternetGatewayAttachment) RenderTerraform(t *terraform.TerraformTarget
 
 	tf := &terraformInternetGateway{
 		VPCID: e.VPC.TerraformLink(),
-		Tags:  cloud.BuildTags(e.InternetGateway.Name, nil),
+		Tags:  cloud.BuildTags(e.InternetGateway.Name),
 	}
 
 	return t.RenderResource("aws_internet_gateway", *e.InternetGateway.Name, tf)

--- a/upup/pkg/fi/cloudup/awstasks/load_balancer.go
+++ b/upup/pkg/fi/cloudup/awstasks/load_balancer.go
@@ -251,5 +251,5 @@ func (_ *LoadBalancer) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *LoadBalan
 		}
 	}
 
-	return t.AddELBTags(*e.ID, t.Cloud.BuildTags(e.Name, nil))
+	return t.AddELBTags(*e.ID, t.Cloud.BuildTags(e.Name))
 }

--- a/upup/pkg/fi/cloudup/awstasks/route.go
+++ b/upup/pkg/fi/cloudup/awstasks/route.go
@@ -52,9 +52,11 @@ func (e *Route) Find(c *fi.Context) (*Route, error) {
 			if aws.StringValue(r.DestinationCidrBlock) != *e.CIDR {
 				continue
 			}
-			actual := &Route{}
-			actual.RouteTable = &RouteTable{ID: rt.RouteTableId}
-			actual.CIDR = r.DestinationCidrBlock
+			actual := &Route{
+				Name:       e.Name,
+				RouteTable: &RouteTable{ID: rt.RouteTableId},
+				CIDR:       r.DestinationCidrBlock,
+			}
 			if r.GatewayId != nil {
 				actual.InternetGateway = &InternetGateway{ID: r.GatewayId}
 			}

--- a/upup/pkg/fi/cloudup/awstasks/routetable.go
+++ b/upup/pkg/fi/cloudup/awstasks/routetable.go
@@ -97,7 +97,7 @@ func (_ *RouteTable) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *RouteTable)
 		e.ID = rt.RouteTableId
 	}
 
-	return t.AddAWSTags(*e.ID, t.Cloud.BuildTags(e.Name, nil))
+	return t.AddAWSTags(*e.ID, t.Cloud.BuildTags(e.Name))
 }
 
 type terraformRouteTable struct {
@@ -110,7 +110,7 @@ func (_ *RouteTable) RenderTerraform(t *terraform.TerraformTarget, a, e, changes
 
 	tf := &terraformRouteTable{
 		VPCID: e.VPC.TerraformLink(),
-		Tags:  cloud.BuildTags(e.Name, nil),
+		Tags:  cloud.BuildTags(e.Name),
 	}
 
 	return t.RenderResource("aws_route_table", *e.Name, tf)

--- a/upup/pkg/fi/cloudup/awstasks/routetableassociation.go
+++ b/upup/pkg/fi/cloudup/awstasks/routetableassociation.go
@@ -55,6 +55,7 @@ func (e *RouteTableAssociation) Find(c *fi.Context) (*RouteTableAssociation, err
 			continue
 		}
 		actual := &RouteTableAssociation{
+			Name:       e.Name,
 			ID:         rta.RouteTableAssociationId,
 			RouteTable: &RouteTable{ID: rta.RouteTableId},
 			Subnet:     &Subnet{ID: rta.SubnetId},

--- a/upup/pkg/fi/cloudup/awstasks/securitygroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygroup.go
@@ -107,7 +107,7 @@ func (_ *SecurityGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Security
 		e.ID = response.GroupId
 	}
 
-	return t.AddAWSTags(*e.ID, t.Cloud.BuildTags(e.Name, nil))
+	return t.AddAWSTags(*e.ID, t.Cloud.BuildTags(e.Name))
 }
 
 type terraformSecurityGroup struct {
@@ -124,7 +124,7 @@ func (_ *SecurityGroup) RenderTerraform(t *terraform.TerraformTarget, a, e, chan
 		Name:        e.Name,
 		VPCID:       e.VPC.TerraformLink(),
 		Description: e.Description,
-		Tags:        cloud.BuildTags(e.Name, nil),
+		Tags:        cloud.BuildTags(e.Name),
 	}
 
 	return t.RenderResource("aws_security_group", *e.Name, tf)

--- a/upup/pkg/fi/cloudup/awstasks/securitygrouprule.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygrouprule.go
@@ -108,6 +108,7 @@ func (e *SecurityGroupRule) Find(c *fi.Context) (*SecurityGroupRule, error) {
 
 	if foundRule != nil {
 		actual := &SecurityGroupRule{
+			Name:          e.Name,
 			SecurityGroup: &SecurityGroup{ID: e.SecurityGroup.ID},
 			FromPort:      foundRule.FromPort,
 			ToPort:        foundRule.ToPort,

--- a/upup/pkg/fi/cloudup/awstasks/subnet.go
+++ b/upup/pkg/fi/cloudup/awstasks/subnet.go
@@ -114,7 +114,7 @@ func (_ *Subnet) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Subnet) error {
 		e.ID = response.Subnet.SubnetId
 	}
 
-	return t.AddAWSTags(*e.ID, t.Cloud.BuildTags(e.Name, nil))
+	return t.AddAWSTags(*e.ID, t.Cloud.BuildTags(e.Name))
 }
 
 func subnetSlicesEqualIgnoreOrder(l, r []*Subnet) bool {
@@ -143,7 +143,7 @@ func (_ *Subnet) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Su
 		VPCID:            e.VPC.TerraformLink(),
 		CIDR:             e.CIDR,
 		AvailabilityZone: e.AvailabilityZone,
-		Tags:             cloud.BuildTags(e.Name, nil),
+		Tags:             cloud.BuildTags(e.Name),
 	}
 
 	return t.RenderResource("aws_subnet", *e.Name, tf)

--- a/upup/pkg/fi/cloudup/awstasks/vpc.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpc.go
@@ -139,7 +139,7 @@ func (_ *VPC) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *VPC) error {
 		}
 	}
 
-	return t.AddAWSTags(*e.ID, t.Cloud.BuildTags(e.Name, nil))
+	return t.AddAWSTags(*e.ID, t.Cloud.BuildTags(e.Name))
 }
 
 type terraformVPC struct {
@@ -154,7 +154,7 @@ func (_ *VPC) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *VPC) 
 
 	tf := &terraformVPC{
 		CIDR:               e.CIDR,
-		Tags:               cloud.BuildTags(e.Name, nil),
+		Tags:               cloud.BuildTags(e.Name),
 		EnableDNSHostnames: e.EnableDNSHostnames,
 		EnableDNSSupport:   e.EnableDNSSupport,
 	}

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -221,7 +221,7 @@ func (c *AWSCloud) CreateELBTags(loadBalancerName string, tags map[string]string
 	}
 }
 
-func (c *AWSCloud) BuildTags(name *string, itemTags map[string]string) map[string]string {
+func (c *AWSCloud) BuildTags(name *string) map[string]string {
 	tags := make(map[string]string)
 	if name != nil {
 		tags["Name"] = *name
@@ -231,10 +231,16 @@ func (c *AWSCloud) BuildTags(name *string, itemTags map[string]string) map[strin
 	for k, v := range c.tags {
 		tags[k] = v
 	}
-	for k, v := range itemTags {
+	return tags
+}
+
+func (c *AWSCloud) AddTags(name *string, tags map[string]string) {
+	if name != nil {
+		tags["Name"] = *name
+	}
+	for k, v := range c.tags {
 		tags[k] = v
 	}
-	return tags
 }
 
 func (c *AWSCloud) BuildFilters(name *string) []*ec2.Filter {

--- a/upup/pkg/kutil/delete_cluster.go
+++ b/upup/pkg/kutil/delete_cluster.go
@@ -39,7 +39,7 @@ func (c *DeleteCluster) ListResources() (map[string]DeletableResource, error) {
 
 	resources := make(map[string]DeletableResource)
 
-	tags := cloud.BuildTags(nil, nil)
+	tags := cloud.BuildTags(nil)
 
 	var filters []*ec2.Filter
 	for k, v := range tags {


### PR DESCRIPTION
A few places we missed populating the name, also compute the actual complete set of tags in advance if we allow tag customization
