### PR TITLE
upup: separate node & master zone configuration; validate

### DIFF
--- a/upup/cmd/cloudup/createcluster_test.go
+++ b/upup/cmd/cloudup/createcluster_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"fmt"
+	"github.com/golang/glog"
+	"k8s.io/kube-deploy/upup/pkg/fi"
+	"k8s.io/kube-deploy/upup/pkg/fi/cloudup"
+	"k8s.io/kube-deploy/upup/pkg/fi/vfs"
+	"testing"
+)
+
+// TODO: Refactor CreateClusterCmd into pkg/fi/cloudup
+
+func buildDefaultCreateCluster() *CreateClusterCmd {
+	var err error
+
+	c := &CreateClusterCmd{}
+
+	c.Config = &cloudup.CloudConfig{}
+	c.Config.ClusterName = "testcluster.mydomain.com"
+	c.Config.NodeZones = []string{"us-east-1a", "us-east-1b", "us-east-1c"}
+	c.Config.MasterZones = c.Config.NodeZones
+	c.SSHPublicKey = "~/.ssh/id_rsa.pub"
+
+	c.Config.CloudProvider = "aws"
+
+	c.StateStore, err = fi.NewVFSStateStore(vfs.NewFSPath("test-state"))
+	if err != nil {
+		glog.Fatalf("error building state store: %v", err)
+	}
+
+	return c
+}
+
+func expectErrorFromRun(t *testing.T, c *CreateClusterCmd, message string) {
+	err := c.Run()
+	if err == nil {
+		t.Fatalf("Expected error from run")
+	}
+	actualMessage := fmt.Sprintf("%v", err)
+	if actualMessage != message {
+		t.Fatalf("Expected error %q, got %q", message, actualMessage)
+	}
+}
+
+func TestCreateCluster_DuplicateZones(t *testing.T) {
+	c := buildDefaultCreateCluster()
+	c.Config.NodeZones = []string{"us-east-1a", "us-east-1b", "us-east-1b"}
+	c.Config.MasterZones = []string{"us-east-1a"}
+	expectErrorFromRun(t, c, "NodeZones contained a duplicate value:  us-east-1b")
+}
+
+func TestCreateCluster_NoClusterName(t *testing.T) {
+	c := buildDefaultCreateCluster()
+	c.Config.ClusterName = ""
+	expectErrorFromRun(t, c, "-name is required (e.g. mycluster.myzone.com)")
+}
+
+func TestCreateCluster_NoCloud(t *testing.T) {
+	c := buildDefaultCreateCluster()
+	c.Config.CloudProvider = ""
+	expectErrorFromRun(t, c, "-cloud is required (e.g. aws, gce)")
+}
+
+func TestCreateCluster_ExtraMasterZone(t *testing.T) {
+	c := buildDefaultCreateCluster()
+	c.Config.NodeZones = []string{"us-east-1a", "us-east-1c"}
+	c.Config.MasterZones = []string{"us-east-1a", "us-east-1b", "us-east-1c"}
+	expectErrorFromRun(t, c, "All MasterZones must (currently) also be NodeZones")
+}
+
+func TestCreateCluster_NoMasterZones(t *testing.T) {
+	c := buildDefaultCreateCluster()
+	c.Config.MasterZones = []string{}
+	expectErrorFromRun(t, c, "must specify at least one MasterZone")
+}
+
+func TestCreateCluster_NoNodeZones(t *testing.T) {
+	c := buildDefaultCreateCluster()
+	c.Config.NodeZones = []string{}
+	expectErrorFromRun(t, c, "must specify at least one NodeZone")
+}
+
+func TestCreateCluster_RegionAsZone(t *testing.T) {
+	c := buildDefaultCreateCluster()
+	c.Config.NodeZones = []string{"us-east-1"}
+	c.Config.MasterZones = c.Config.NodeZones
+	expectErrorFromRun(t, c, "Region is not a recognized EC2 region: \"us-east-\" (check you have specified valid zones?)")
+}
+
+func TestCreateCluster_BadZone(t *testing.T) {
+	c := buildDefaultCreateCluster()
+	c.Config.NodeZones = []string{"us-east-1z"}
+	c.Config.MasterZones = c.Config.NodeZones
+	expectErrorFromRun(t, c, "Zone is not a recognized AZ: \"us-east-1z\" (check you have specified a valid zone?)")
+}
+
+func TestCreateCluster_MixedRegion(t *testing.T) {
+	c := buildDefaultCreateCluster()
+	c.Config.NodeZones = []string{"us-west-1a", "us-west-2b", "us-west-2c"}
+	c.Config.MasterZones = c.Config.NodeZones
+	expectErrorFromRun(t, c, "Clusters cannot span multiple regions")
+}
+
+func TestCreateCluster_EvenEtcdClusterSize(t *testing.T) {
+	c := buildDefaultCreateCluster()
+	c.Config.NodeZones = []string{"us-east-1a", "us-east-1b", "us-east-1c", "us-east-1d"}
+	c.Config.MasterZones = c.Config.NodeZones
+	expectErrorFromRun(t, c, "There should be an odd number of master-zones, for etcd's quorum.  Hint: Use -zone and -master-zone to declare node zones and master zones separately.")
+}

--- a/upup/models/cloudup/_aws/network.yaml
+++ b/upup/models/cloudup/_aws/network.yaml
@@ -25,7 +25,7 @@ routeTable/kubernetes.{{ .ClusterName }}:
   vpc: vpc/kubernetes.{{ .ClusterName }}
 
 
-{{ range $zone := .Zones }}
+{{ range $zone := .NodeZones }}
 
 subnet/kubernetes.{{ $zone }}.{{ $.ClusterName }}:
   vpc: vpc/kubernetes.{{ $.ClusterName }}

--- a/upup/pkg/fi/cloudup/awsup/aws_utils.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_utils.go
@@ -1,0 +1,38 @@
+package awsup
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/glog"
+	"os"
+)
+
+// ValidateRegion checks that an AWS region name is valid
+func ValidateRegion(region string) error {
+	glog.V(2).Infof("Querying EC2 for all valid regions")
+
+	request := &ec2.DescribeRegionsInput{}
+	config := aws.NewConfig().WithRegion("us-east-1")
+	client := ec2.New(session.New(), config)
+
+	response, err := client.DescribeRegions(request)
+
+	if err != nil {
+		return fmt.Errorf("Got an error while querying for valid regions (verify your AWS credentials?)")
+	}
+	for _, r := range response.Regions {
+		name := aws.StringValue(r.RegionName)
+		if name == region {
+			return nil
+		}
+	}
+
+	if os.Getenv("SKIP_REGION_CHECK") != "" {
+		glog.Infof("AWS region does not appear to be valid, but skipping because SKIP_REGION_CHECK is set")
+		return nil
+	}
+
+	return fmt.Errorf("Region is not a recognized EC2 region: %q (check you have specified valid zones?)", region)
+}

--- a/upup/pkg/fi/cloudup/config.go
+++ b/upup/pkg/fi/cloudup/config.go
@@ -19,7 +19,6 @@ type CloudConfig struct {
 	NodeInit string `json:",omitempty"`
 
 	// Configuration of zones we are targeting
-	Zones       []string `json:",omitempty"`
 	MasterZones []string `json:",omitempty"`
 	NodeZones   []string `json:",omitempty"`
 	Region      string   `json:",omitempty"`
@@ -184,12 +183,11 @@ func (c *CloudConfig) WellKnownServiceIP(id int) (net.IP, error) {
 	}
 
 	return nil, fmt.Errorf("Unexpected IP address type for ServiceClusterIPRange: %s", c.ServiceClusterIPRange)
-
 }
 
 func (c *CloudConfig) SubnetCIDR(zone string) (string, error) {
 	index := -1
-	for i, z := range c.Zones {
+	for i, z := range c.NodeZones {
 		if z == zone {
 			index = i
 			break


### PR DESCRIPTION
We allow --zones & --master-zones to be specified separately now, but we
validate for common errors (using a region where you meant a zone,
duplicating a zone, spanning regions, entering an invalid AZ etc)
