### PR TITLE
upup: allow -dns-zone to be specified

### DIFF
--- a/upup/README.md
+++ b/upup/README.md
@@ -71,9 +71,13 @@ You must pass --yes to actually delete resources (without the `#` comment!)
 
 * Try HA mode: `-zone=us-east-1b,us-east-1c,us-east-1d`
 
+* Specify the number of nodes: `-node-count=4`
+
 * Specify the node size: `-node-size=m4.large`
 
-* Specify the number of nodes: `-node-count=4`
+* Specify the master size: `-master-size=m4.large`
+
+* Override the default DNS zone: `-dns-zone=<my.hosted.zone>`
 
 # How it works
 

--- a/upup/cmd/cloudup/main.go
+++ b/upup/cmd/cloudup/main.go
@@ -57,6 +57,9 @@ func main() {
 	nodeCount := 0
 	flag.IntVar(&nodeCount, "node-count", nodeCount, "Set the number of nodes")
 
+	dnsZone := ""
+	flag.StringVar(&dnsZone, "dns-zone", dnsZone, "DNS hosted zone to use (defaults to last two components of cluster name)")
+
 	flag.Parse()
 
 	config.Zones = strings.Split(zones, ",")
@@ -69,6 +72,10 @@ func main() {
 	}
 	if nodeCount != 0 {
 		config.NodeCount = nodeCount
+	}
+
+	if dnsZone != "" {
+		config.DNSZone = dnsZone
 	}
 
 	if dryrun {
@@ -155,6 +162,7 @@ func (c *CreateClusterCmd) Run() error {
 	if c.Config.DNSZone == "" {
 		tokens := strings.Split(c.Config.MasterPublicName, ".")
 		c.Config.DNSZone = strings.Join(tokens[len(tokens)-2:], ".")
+		glog.Infof("Defaulting DNS zone to: %s", c.Config.DNSZone)
 	}
 
 	if c.StateStore == nil {


### PR DESCRIPTION
We default to the last two components of the cluster DNS name.  But a
lot of people will delelgate a subdomain and want to use that.

Fixes #98
