### PR TITLE
upup: Mark GCE as probably-not-working

### DIFF
--- a/upup/cmd/cloudup/main.go
+++ b/upup/cmd/cloudup/main.go
@@ -446,6 +446,7 @@ func (c *CreateClusterCmd) Run() error {
 	switch c.Config.CloudProvider {
 	case "gce":
 		{
+			glog.Fatalf("GCE is (probably) not working currently - please ping @justinsb for cleanup")
 			tags["_gce"] = struct{}{}
 			c.Config.NodeUpTags = append(c.Config.NodeUpTags, "_gce")
 

--- a/upup/pkg/kutil/upgrade_cluster.go
+++ b/upup/pkg/kutil/upgrade_cluster.go
@@ -51,7 +51,7 @@ func (x *UpgradeCluster) Upgrade() error {
 
 	dhcpOptions, err := DescribeDhcpOptions(x.Cloud)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// Find masters
@@ -124,7 +124,7 @@ func (x *UpgradeCluster) Upgrade() error {
 	// Retag DHCP options
 	// We have to be careful because DHCP options can be shared
 	for _, dhcpOption := range dhcpOptions {
-		clusterTag := dhcpOption.Tags[awsup.TagClusterName]
+		clusterTag, _ := awsup.FindEC2Tag(dhcpOption.Tags, awsup.TagClusterName)
 		if clusterTag != "" {
 			if clusterTag != oldClusterName {
 				return fmt.Errorf("DHCP options are tagged with a different cluster: %v", clusterTag)


### PR DESCRIPTION
I'm about to do a demo of this, and GCE is lagging, so I'd like to warn users early that GCE may not be in-sync with the latest
