### PR TITLE
upup/protokube: tell protokube to use --dns-zone-name

### DIFF
--- a/upup/models/cloudup/_aws/resources/nodeup.sh.template
+++ b/upup/models/cloudup/_aws/resources/nodeup.sh.template
@@ -90,7 +90,7 @@ function try-download-release() {
   download-or-bust "${nodeup_tar_hash}" "${nodeup_tar_urls[@]}"
 
   echo "Unpacking and checking integrity of nodeup"
-  rm -rf nodeupcurl https://kubeupv2.s3.amazonaws.com/nodeup/nodeup.tar.gz
+  rm -rf nodeupcurl ${nodeup_tar_urls[@]}
 
   tar xzf "${nodeup_tar}" && tar tzf "${nodeup_tar}" > /dev/null
 }

--- a/upup/models/cloudup/_gce/resources/nodeup.sh.template
+++ b/upup/models/cloudup/_gce/resources/nodeup.sh.template
@@ -114,7 +114,7 @@ function try-download-release() {
   download-or-bust "${nodeup_tar_hash}" "${nodeup_tar_urls[@]}"
 
   echo "Unpacking and checking integrity of nodeup"
-  rm -rf nodeupcurl https://kubeupv2.s3.amazonaws.com/nodeup/nodeup.tar.gz
+  rm -rf nodeupcurl ${nodeup_tar_urls[@]}
 
   tar xzf "${nodeup_tar}" && tar tzf "${nodeup_tar}" > /dev/null
 }

--- a/upup/models/nodeup/_protokube/files/etc/sysconfig/protokube.template
+++ b/upup/models/nodeup/_protokube/files/etc/sysconfig/protokube.template
@@ -1,5 +1,5 @@
 {{ if HasTag "_kubernetes_master" }}
-DAEMON_ARGS="--master=true --containerized --v=8"
+DAEMON_ARGS="--dns-zone-name={{ .DNSZone }} --master=true --containerized --v=8"
 {{ else }}
-DAEMON_ARGS="--master=false --containerized --v=8"
+DAEMON_ARGS="--dns-zone-name={{ .DNSZone }} --master=false --containerized --v=8"
 {{ end }}


### PR DESCRIPTION
Poking around the project for the first time, looking good!

My test domain was `whatever.aws.slack.io` with the zone `aws.slack.io` hosted
on Route53. With this configuration protokube kept crashing with nil pointer
because it was detecting the wrong zone rather than using the configured zone
from cloudup:

```
${GOPATH}/bin/cloudup --state=s3://busket/hatever --name=${MYZONE} \
    --zones=us-west-2a --cloud=aws --dns-zone aws.slack.io --v=8 --logtostderr

Jun 26 04:15:26 ip-172-20-35-205 docker[4492]: I0626 04:15:26.539800       1 aws_dns.go:33] AWS API Request: route53/ListHostedZonesByName
Jun 26 04:15:26 ip-172-20-35-205 docker[4492]: panic: runtime error: invalid memory address or nil pointer dereference
Jun 26 04:15:26 ip-172-20-35-205 docker[4492]: [signal 0xb code=0x1 addr=0x10 pc=0x4868a0]
Jun 26 04:15:26 ip-172-20-35-205 docker[4492]: goroutine 1 [running]:
Jun 26 04:15:26 ip-172-20-35-205 docker[4492]: panic(0xa09bc0, 0xc820012070)
Jun 26 04:15:26 ip-172-20-35-205 docker[4492]: /usr/local/go/src/runtime/panic.go:481 +0x3e6
Jun 26 04:15:26 ip-172-20-35-205 docker[4492]: k8s.io/kube-deploy/protokube/pkg/protokube.(*Route53DNSProvider).Set(0xc8203d8200, 0xc8203a08a0, 0x29, 0xb0b6b0, 0x1, 0xc8203b0280, 0xd, 0xdf8475800, 0x0, 0x0)
Jun 26 04:15:26 ip-172-20-35-205 docker[4492]: /go/src/k8s.io/kube-deploy/protokube/pkg/protokube/aws_dns.go:103 +0x4d0
Jun 26 04:15:26 ip-172-20-35-205 docker[4492]: k8s.io/kube-deploy/protokube/pkg/protokube.(*KubeBoot).MapInternalDNSName(0xc820197ea0, 0xc8203a08a0, 0x29, 0x0, 0x0)
```

Smooth sailing after adding `--dons-zone-name` to `/etc/sysconfig/protokube`!

I also discovered a small bug when trying to use a custom nodeup location.
`nodeup.sh` wasn't using the download URL passed in via `NODEUP_TAR_URL`.

I'd be happy to split these into two PRs if you'd rather one over the other!
