### PR TITLE
Fix changing mtu and bip in DOCKER OPTIONS file

### DIFF
--- a/docker-multinode/common.sh
+++ b/docker-multinode/common.sh
@@ -238,7 +238,7 @@ kube::multinode::restart_docker(){
 
       # Is there an uncommented OPTIONS line at all?
       if [[ -z $(grep "OPTIONS" ${DOCKER_CONF} | grep -v "#") ]]; then
-        echo "OPTIONS=\"--mtu=${FLANNEL_MTU} --bip=${FLANNEL_SUBNET}\"" >> ${DOCKER_CONF}
+        echo "OPTIONS=\"--mtu=${FLANNEL_MTU} --bip=${FLANNEL_SUBNET} \"" >> ${DOCKER_CONF}
       else
         kube::helpers::replace_mtu_bip ${DOCKER_CONF} "OPTIONS"
       fi
@@ -264,7 +264,7 @@ kube::multinode::restart_docker(){
 
         # Is there an uncommented OPTIONS line at all?
         if [[ -z $(grep "OPTIONS" ${DOCKER_CONF} | grep -v "#") ]]; then
-          echo "OPTIONS=\"--mtu=${FLANNEL_MTU} --bip=${FLANNEL_SUBNET}\"" >> ${DOCKER_CONF}
+          echo "OPTIONS=\"--mtu=${FLANNEL_MTU} --bip=${FLANNEL_SUBNET} \"" >> ${DOCKER_CONF}
         else
           kube::helpers::replace_mtu_bip ${DOCKER_CONF} "OPTIONS"
         fi
@@ -288,7 +288,7 @@ kube::multinode::restart_docker(){
         
         # Is there an uncommented DOCKER_OPTS line at all?
         if [[ -z $(grep "DOCKER_OPTS" $DOCKER_CONF | grep -v "#") ]]; then
-          echo "DOCKER_OPTS=\"--mtu=${FLANNEL_MTU} --bip=${FLANNEL_SUBNET}\"" >> ${DOCKER_CONF}
+          echo "DOCKER_OPTS=\"--mtu=${FLANNEL_MTU} --bip=${FLANNEL_SUBNET} \"" >> ${DOCKER_CONF}
         else
           kube::helpers::replace_mtu_bip ${DOCKER_CONF} "DOCKER_OPTS"
         fi
@@ -502,6 +502,8 @@ kube::helpers::replace_mtu_bip(){
 
   # Finds "--mtu=????" and replaces with "--mtu=${FLANNEL_MTU}"
   # Also finds "--bip=??.??.??.??" and replaces with "--bip=${FLANNEL_SUBNET}"
+  # NOTE: This method replaces a whole 'mtu' or 'bip' expression. If it ends with a punctuation mark it will be truncated.
+  # Please add additional space before the punctuation mark to prevent this. For example: "--mtu=${FLANNEL_MTU} --bip=${FLANNEL_SUBNET} ".
   sed -e "s@$(grep -o -- "--mtu=[[:graph:]]*" $DOCKER_CONF)@--mtu=${FLANNEL_MTU}@g;s@$(grep -o -- "--bip=[[:graph:]]*" $DOCKER_CONF)@--bip=${FLANNEL_SUBNET}@g" -i $DOCKER_CONF
 }
 


### PR DESCRIPTION
Modifying  bip and mtu in docker OPTIONS file causes problem when master/worker script is run again. The kube::helpers::replace_mtu_bip() function truncates last punctuation mark and docker crashes after restart. This PR fix this issue.
