### PR TITLE
Replaces emptyDir in manifest-multi to use hostPath and introduces wo…

### DIFF
--- a/docker-multinode/common.sh
+++ b/docker-multinode/common.sh
@@ -35,6 +35,9 @@ kube::multinode::main(){
   DEFAULT_NET_INTERFACE=$(ip -o -4 route show to default | awk '{print $5}')
   NET_INTERFACE=${NET_INTERFACE:-${DEFAULT_NET_INTERFACE}}
 
+  # Work directory
+  WORKDIR=$BASEDIR/work
+
   # Constants
   TIMEOUT_FOR_SERVICES=20
   BOOTSTRAP_DOCKER_SOCK="unix:///var/run/docker-bootstrap.sock"
@@ -43,10 +46,18 @@ kube::multinode::main(){
     -v /var/run:/var/run:rw \
     -v /var/lib/docker:/var/lib/docker:rw \
     -v /var/lib/kubelet:/var/lib/kubelet:shared \
-    -v /var/log/containers:/var/log/containers:rw"
+    -v /var/log/containers:/var/log/containers:rw \
+    -v $WORKDIR/etc/kubernetes:/etc/kubernetes:rw"
 
   # Paths
-  FLANNEL_SUBNET_TMPDIR=$(mktemp -d)
+  DATADIR=$WORKDIR/data
+  ETCD_DATA=$WORKDIR/etcd/data
+  FLANNEL_SUBNET_TMPDIR=$WORKDIR/flannel
+
+  mkdir -p $FLANNEL_SUBNET_TMPDIR
+  mkdir -p $DATADIR
+  mkdir -p $ETCD_DATA
+  mkdir -p $WORKDIR/etc
 
   # Trap errors
   kube::log::install_errexit
@@ -153,10 +164,11 @@ kube::multinode::bootstrap_daemon() {
 kube::multinode::start_etcd() {
 
   kube::log::status "Launching etcd..."
-  
+
   docker -H ${BOOTSTRAP_DOCKER_SOCK} run -d \
     --restart=${RESTART_POLICY} \
     --net=host \
+    -v $ETCD_DATA:/var/etcd/data \
     gcr.io/google_containers/etcd-${ARCH}:${ETCD_VERSION} \
     /usr/local/bin/etcd \
       --listen-client-urls=http://127.0.0.1:4001,http://${MASTER_IP}:4001 \
@@ -244,7 +256,7 @@ kube::multinode::restart_docker(){
       fi
 
       ifconfig docker0 down
-      brctl delbr docker0 
+      brctl delbr docker0
       service docker restart
       ;;
     centos)
@@ -254,7 +266,7 @@ kube::multinode::restart_docker(){
       if ! kube::helpers::command_exists brctl; then
         yum -y -q install bridge-utils
       fi
-      
+
       # Newer centos releases uses systemd. Handle that
       if kube::helpers::command_exists systemctl; then
         kube::multinode::restart_docker_systemd
@@ -270,13 +282,13 @@ kube::multinode::restart_docker(){
         fi
 
         ifconfig docker0 down
-        brctl delbr docker0 
+        brctl delbr docker0
         systemctl restart docker
       fi
       ;;
     ubuntu|debian)
       if ! kube::helpers::command_exists brctl; then
-        apt-get install -y bridge-utils 
+        apt-get install -y bridge-utils
       fi
 
       # Newer ubuntu and debian releases uses systemd. Handle that
@@ -285,7 +297,7 @@ kube::multinode::restart_docker(){
       else
         DOCKER_CONF="/etc/default/docker"
         kube::helpers::backup_file ${DOCKER_CONF}
-        
+
         # Is there an uncommented DOCKER_OPTS line at all?
         if [[ -z $(grep "DOCKER_OPTS" $DOCKER_CONF | grep -v "#") ]]; then
           echo "DOCKER_OPTS=\"--mtu=${FLANNEL_MTU} --bip=${FLANNEL_SUBNET}\"" >> ${DOCKER_CONF}
@@ -294,7 +306,7 @@ kube::multinode::restart_docker(){
         fi
 
         ifconfig docker0 down
-        brctl delbr docker0 
+        brctl delbr docker0
         service docker stop
         while [[ $(ps aux | grep $(which docker) | grep -v grep | wc -l) -gt 0 ]]; do
             kube::log::status "Waiting for docker to terminate"
@@ -326,10 +338,25 @@ kube::multinode::restart_docker_systemd(){
   systemctl restart docker
 }
 
+kube::multinode::use_hostpath() {
+  CONTAINER_NAME=hyperkube.$RANDOM
+
+  docker run --name $CONTAINER_NAME \
+    gcr.io/google_containers/hyperkube-${ARCH}:${K8S_VERSION}
+
+  docker cp $CONTAINER_NAME:/etc/kubernetes $WORKDIR/etc/
+  docker rm $CONTAINER_NAME
+
+  for i in $WORKDIR/etc/kubernetes/manifests-multi/*; do \
+  sed -i -e "s;\"emptyDir\": {};\"hostPath\": { \"path\": \"$DATADIR\" };g" "$i"; done
+}
+
 # Start kubelet first and then the master components as pods
 kube::multinode::start_k8s_master() {
-  
+
   kube::log::status "Launching Kubernetes master components..."
+
+  kube::multinode::use_hostpath
 
   kube::multinode::make_shared_kubelet_dir
 
@@ -353,7 +380,7 @@ kube::multinode::start_k8s_master() {
 
 # Start kubelet in a container, for a worker node
 kube::multinode::start_k8s_worker() {
-  
+
   kube::log::status "Launching Kubernetes worker components..."
 
   kube::multinode::make_shared_kubelet_dir
@@ -381,7 +408,7 @@ kube::multinode::start_k8s_worker_proxy() {
 
   # Some quite complex version checking here...
   # If the version is under v1.3.0-alpha.5, kube-proxy is run manually in this script
-  # In v1.3.0-alpha.5 and above, kube-proxy is run in a DaemonSet 
+  # In v1.3.0-alpha.5 and above, kube-proxy is run in a DaemonSet
   # This has been uncommented for now, since the DaemonSet was inactivated in the stable v1.3 release
   #if [[ $((VERSION_MINOR < 3)) == 1 || \
   #      $((VERSION_MINOR <= 3)) == 1 && \
@@ -419,7 +446,7 @@ kube::multinode::turndown(){
   fi
 
   if [[ $(kube::helpers::is_running /hyperkube) == "true" ]]; then
-    
+
     kube::log::status "Killing hyperkube containers..."
 
     # Kill all hyperkube docker images
@@ -427,7 +454,7 @@ kube::multinode::turndown(){
   fi
 
   if [[ $(kube::helpers::is_running /pause) == "true" ]]; then
-    
+
     kube::log::status "Killing pause containers..."
 
     # Kill all pause docker images
@@ -561,7 +588,7 @@ kube::helpers::host_platform() {
       host_arch=arm;;
     ppc64le*)
       host_arch=ppc64le;;
-    *)  
+    *)
       kube::log::error "Unsupported host arch. Must be x86_64, arm, arm64 or ppc64le."
       exit 1;;
   esac
@@ -671,4 +698,3 @@ kube::log::error() {
     echo "    $message" >&2
   done
 }
-

--- a/docker-multinode/master.sh
+++ b/docker-multinode/master.sh
@@ -14,8 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Basedir for multinode
+BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 # Source common.sh
-source $(dirname "${BASH_SOURCE}")/common.sh
+source $BASEDIR/common.sh
 
 # Let MASTER_IP default to the current IP when starting a master
 if [[ -z ${MASTER_IP} ]]; then


### PR DESCRIPTION
…rk-directory. Currently apiserver uses a emptyDir to store generated certs. When the apiserver dies all certs are re-generated. That makes all pods that depends on apiserver fail (like dns). This PR copies manifests-multinode and changes emtyDir to hostPath so that generated files are reused. It also introduces work-dir to keep persistent data between restarts (etcd).
