### PR TITLE
[WIP] Flannel and kube-proxy daemonsets

### DIFF
--- a/docker-multinode/master.sh
+++ b/docker-multinode/master.sh
@@ -18,7 +18,7 @@
 source $(dirname "${BASH_SOURCE}")/common.sh
 
 # Set MASTER_IP to localhost when deploying a master
-MASTER_IP=localhost
+MASTER_IP=$(ip -o -4 addr list $(ip -o -4 route show to default | awk '{print $5}' | head -1) | awk '{print $4}' | cut -d/ -f1 | head -1)
 
 kube::multinode::main
 
@@ -31,7 +31,11 @@ if [[ ${USE_CNI} == "true" ]]; then
 
   kube::multinode::start_etcd
 
-  kube::multinode::start_flannel
+  # hyperkube versions prior to v1.4.0-alpha.3 do not have a flannel daemonset
+  # TODO: remove later
+  if [[ $((VERSION_MINOR < 4)) == 1 ]]; then
+    kube::multinode::start_flannel
+  fi
 else
   kube::bootstrap::bootstrap_daemon
 

--- a/docker-multinode/worker.sh
+++ b/docker-multinode/worker.sh
@@ -32,7 +32,11 @@ kube::multinode::turndown
 if [[ ${USE_CNI} == "true" ]]; then
   kube::cni::ensure_docker_settings
 
-  kube::multinode::start_flannel
+  # hyperkube versions prior to v1.4.0-alpha.3 do not have a flannel daemonset
+  # TODO: remove later
+  if [[ $((VERSION_MINOR < 4)) == 1 ]]; then
+    kube::multinode::start_flannel
+  fi
 else
   kube::bootstrap::bootstrap_daemon
 


### PR DESCRIPTION
#### [WIP] Please do not merge yet

This builds upon https://github.com/kubernetes/kube-deploy/issues/176
Since CNI has been merged into `docker-multinode` with https://github.com/kubernetes/kube-deploy/pull/115, it would be great to have self hosted flannel and kube-proxy as daemon-sets. That is what this pull request is about.

Most of the work for this is in the hyperkube: see PR https://github.com/kubernetes/kubernetes/pull/29848, which goes hand in hand with this one.

The biggest issue is how to cleanly propagate configuration (such as the MASTER_IP) to the daemonsets.

I've tested this in a two node setup, all addons were running correctly and I managed to deploy the guestbook example without issues.

@luxas @cheld @zreigz 
