### PR TITLE
Add Vagrant enviroment to execute e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.gitignore
+docker-multinode/test/.vagrant/

--- a/docker-multinode/test/README.md
+++ b/docker-multinode/test/README.md
@@ -1,0 +1,38 @@
+# Running e2e conformance tests
+
+The purpose of this project is to easily fire up a VMs with a running Kubernetes cluster
+and test machine to run e2e conformance tests.
+
+## Prerequisites
+
+- Vagrant 1.8.1+
+- Ansible 1.9+
+
+## Configuration
+
+All global variables are stored in `group_vars/all.yaml` file.
+You can setup:
+ - master_ip - master IP address used in all VMs. This value depends on Vagrant network configuration in Vagrantfile.
+ - use_cni - boolean flag indicates if CNI plugin must be used for cluster network.
+ - k8s_version - sets released version of kubernetes which must be used in cluster.
+
+## Start VMs
+
+There are three VMs called: *master*, *node* and *tests*
+
+To start each machine execute commands:
+
+```
+vagrant up master
+vagrant up node
+vagrant up tests
+```
+
+## Getting tests result
+
+When all VMs are up and running you can check e2e tests result. Logs are stored in file
+`/home/vagrant/e2e.txt` on `tests` VM. You can get the logs content using the following command:
+
+```
+vagrant ssh -c 'tail -f /home/vagrant/e2e.txt' tests
+```

--- a/docker-multinode/test/Vagrantfile
+++ b/docker-multinode/test/Vagrantfile
@@ -1,0 +1,67 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def configure_vm(vm, **opts)
+
+    vm.box = opts.fetch(:box, "bento/ubuntu-16.04")
+    vm.network :private_network, ip: opts[:private_ip]
+
+    vm.provider "virtualbox" do |vb|
+      vb.memory = 4096
+      vb.cpus = 2
+    end
+    
+    # Disable default share, because we dont use it
+    vm.synced_folder ".", "/vagrant", disabled: true
+end
+
+
+def apply_ansible(vm, playbook)
+    vm.provision :ansible do |ansible|
+        ansible.host_key_checking = false
+        ansible.playbook = playbook
+        ansible.verbose = "v"
+    end
+end
+
+
+Vagrant.configure(2) do |config|
+    # ---------------------------------------------------------------------------------------------
+    #
+    # Definition of the VM for running kubernetes master.
+    #
+    config.vm.define "master" do |master|
+        configure_vm(master.vm, private_ip: "10.9.8.7")
+        apply_ansible(master.vm, "ansible-master.yaml")
+    end
+
+
+    # ---------------------------------------------------------------------------------------------
+    #
+    # Definition of the VM for running kubernetes node.
+    #
+    config.vm.define "node" do |node|
+        configure_vm(node.vm, private_ip: "10.9.8.6")
+        apply_ansible(node.vm, "ansible-node.yaml")
+    end
+
+    # ---------------------------------------------------------------------------------------------
+    #
+    # Definition of the VM for running tests.
+    #
+    config.vm.define "tests" do |node|
+        configure_vm(node.vm, private_ip: "10.9.8.5")
+        apply_ansible(node.vm, "ansible-test.yaml")
+    end
+end

--- a/docker-multinode/test/ansible-master.yaml
+++ b/docker-multinode/test/ansible-master.yaml
@@ -1,0 +1,26 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- hosts: all
+  sudo: yes
+  roles:
+    - common
+    - master
+    
+  environment:
+    MASTER_IP: "{{ master_ip }}"
+    IP_ADDRESS: "{{ master_ip }}"
+    USE_CNI: "{{ use_cni }}"
+    K8S_VERSION: "{{ k8s_version }}"

--- a/docker-multinode/test/ansible-node.yaml
+++ b/docker-multinode/test/ansible-node.yaml
@@ -1,0 +1,26 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- hosts: all
+  sudo: yes
+  roles:
+    - common
+    - node
+    
+  environment:
+    MASTER_IP: "{{ master_ip }}"
+    IP_ADDRESS: "{{ node_ip }}"
+    USE_CNI: "{{ use_cni }}"
+    K8S_VERSION: "{{ k8s_version }}"

--- a/docker-multinode/test/ansible-test.yaml
+++ b/docker-multinode/test/ansible-test.yaml
@@ -1,0 +1,25 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- hosts: all
+  sudo: yes
+  roles:
+    - tests
+
+  environment:
+    MASTER_IP: "{{ master_ip }}"
+    KUBERNETES_PROVIDER: skeleton
+    GINKGO_PARALLEL: y
+    KUBERNETES_CONFORMANCE_TEST: y

--- a/docker-multinode/test/group_vars/all.yaml
+++ b/docker-multinode/test/group_vars/all.yaml
@@ -1,0 +1,6 @@
+---
+
+master_ip: 10.9.8.7
+node_ip: 10.9.8.6
+use_cni: false
+k8s_version: ""

--- a/docker-multinode/test/roles/common/defaults/main.yaml
+++ b/docker-multinode/test/roles/common/defaults/main.yaml
@@ -1,0 +1,16 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+repo: https://github.com/kubernetes/kube-deploy.git
+version: master

--- a/docker-multinode/test/roles/common/tasks/main.yaml
+++ b/docker-multinode/test/roles/common/tasks/main.yaml
@@ -1,0 +1,42 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+- name: add docker apt key
+  apt_key:
+    keyserver: hkp://p80.pool.sks-keyservers.net:80
+    id: 58118E89F3A912897C070ADBF76221572C52609D
+
+- name: add docker apt repository
+  apt_repository:
+    repo: 'deb https://apt.dockerproject.org/repo ubuntu-xenial main'
+
+- name: install docker
+  apt:
+    name: docker-engine
+
+- name: install git
+  apt: name=git
+  become: True
+
+- name: install curl
+  apt: name=curl
+  become: True
+
+- name: checkout kube-deploy
+  git: repo={{ repo }} dest=/home/vagrant/kube-deploy version={{ version }} accept_hostkey=yes
+  become: true
+  become_user: vagrant
+  become_method: sudo

--- a/docker-multinode/test/roles/master/tasks/main.yaml
+++ b/docker-multinode/test/roles/master/tasks/main.yaml
@@ -1,0 +1,18 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+- name: start master
+  command: /home/vagrant/kube-deploy/docker-multinode/master.sh

--- a/docker-multinode/test/roles/node/tasks/main.yaml
+++ b/docker-multinode/test/roles/node/tasks/main.yaml
@@ -1,0 +1,18 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+- name: start worker
+  command: /home/vagrant/kube-deploy/docker-multinode/worker.sh

--- a/docker-multinode/test/roles/tests/defaults/main.yaml
+++ b/docker-multinode/test/roles/tests/defaults/main.yaml
@@ -1,0 +1,20 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+go_tarball: "go1.6.1.linux-amd64.tar.gz"
+go_location: "https://storage.googleapis.com/golang/{{ go_tarball }}"
+k8s_repo: https://github.com/kubernetes/kubernetes.git
+k8s_branch: master

--- a/docker-multinode/test/roles/tests/files/conformance-test.sh
+++ b/docker-multinode/test/roles/tests/files/conformance-test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# exit on any error
+set -e
+
+cd /home/vagrant/kubernetes
+. /etc/profile.d/go-path.sh
+go get -u github.com/jteeuwen/go-bindata/go-bindata
+make all WHAT=cmd/kubectl
+make all WHAT=vendor/github.com/onsi/ginkgo/ginkgo
+make all WHAT=test/e2e/e2e.test
+cluster/kubectl.sh config set-cluster local --server=http://${MASTER_IP}:8080 --insecure-skip-tls-verify=true
+cluster/kubectl.sh config set-context local --cluster=local
+cluster/kubectl.sh config use-context local
+nohup go run hack/e2e.go --v --test -check_version_skew=false --test_args="--ginkgo.skip=\[Serial\]|\[Flaky\]|\[Feature:.+\]" > /home/vagrant/e2e.txt &

--- a/docker-multinode/test/roles/tests/files/go-path.sh
+++ b/docker-multinode/test/roles/tests/files/go-path.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+export PATH=$PATH:/usr/local/go/bin
+export GOPATH=$HOME/go
+export PATH=$GOPATH/bin:$PATH

--- a/docker-multinode/test/roles/tests/tasks/main.yaml
+++ b/docker-multinode/test/roles/tests/tasks/main.yaml
@@ -1,0 +1,46 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+- name: download the Go tarball
+  get_url: url={{ go_location }}
+           dest=/usr/local/src/{{ go_tarball }}
+
+- name: extract the Go tarball
+  unarchive: src=/usr/local/src/{{ go_tarball }}
+             dest=/usr/local
+             copy=no
+
+- name: set GOPATH for all users
+  copy: src=go-path.sh
+        dest=/etc/profile.d mode=0755 owner=root group=root
+
+- name: install git
+  apt: name=git
+  become: True
+
+- name: checkout kubernetes
+  git: repo={{ k8s_repo }} dest=/home/vagrant/kubernetes version={{ k8s_branch }} accept_hostkey=yes
+  become: true
+  become_user: vagrant
+  become_method: sudo
+
+- name: copy conformance-test.sh script
+  copy: src=conformance-test.sh
+        dest=/home/vagrant/conformance-test.sh
+        mode=0755 owner=vagrant group=vagrant
+
+- name: start e2e tests
+  shell: /home/vagrant/conformance-test.sh


### PR DESCRIPTION
The purpose of this PR is to easily set up a VMs with a running Kubernetes cluster and test machine to run e2e conformance tests.

Start master and node to create k8s cluster

```
vagrant up master
vagrant up node
```

and then start test VM

```
vagrant up tests
```

When it is up and running get e2e tests result

```
vagrant ssh -c 'tail -f /home/vagrant/e2e.txt' tests
```

The final test result for official release v1.3.4:

```
Summarizing 12 Failures:

[Fail] [k8s.io] ResourceQuota [It] should create a ResourceQuota and capture the life of a pod. 
/home/vagrant/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/resource_quota.go:140

[Fail] [k8s.io] ResourceQuota [It] should create a ResourceQuota and capture the life of a service. 
/home/vagrant/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/resource_quota.go:61

[Fail] [k8s.io] Networking [It] should function for intra-pod communication [Conformance] 
/home/vagrant/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/networking.go:154

[Fail] [k8s.io] Kubectl client [k8s.io] Simple pod [It] should support exec through an HTTP proxy 
/home/vagrant/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/kubectl.go:346

[Fail] [k8s.io] ResourceQuota [It] should create a ResourceQuota and capture the life of a persistent volume claim. 
/home/vagrant/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/resource_quota.go:275

[Fail] [k8s.io] ResourceQuota [It] should create a ResourceQuota and ensure its status is promptly calculated. 
/home/vagrant/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/resource_quota.go:47

[Fail] [k8s.io] ResourceQuota [It] should create a ResourceQuota and capture the life of a configMap. 
/home/vagrant/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/resource_quota.go:205

[Fail] [k8s.io] ResourceQuota [It] should create a ResourceQuota and capture the life of a replication controller. 
/home/vagrant/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/resource_quota.go:240

[Fail] [k8s.io] ResourceQuota [It] should create a ResourceQuota and capture the life of a secret. 
/home/vagrant/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/resource_quota.go:103

[Fail] [k8s.io] Deployment [It] paused deployment should be able to scale 
/home/vagrant/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/deployment.go:1012

[Fail] [k8s.io] [HPA] Horizontal pod autoscaling (scale resource: CPU) [k8s.io] ReplicationController light [It] Should scale from 1 pod to 2 pods 
/home/vagrant/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/autoscaling_utils.go:284

[Fail] [k8s.io] [HPA] Horizontal pod autoscaling (scale resource: CPU) [k8s.io] ReplicationController light [It] Should scale from 2 pods to 1 pod 
/home/vagrant/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/autoscaling_utils.go:284

Ran 185 of 340 Specs in 1812.087 seconds
FAIL! -- 173 Passed | 12 Failed | 0 Pending | 155 Skipped 

```

TODO 
Extract common variable to group_vars to be able setup K8S_VERSION and USE_CNI in one place because currently it uses LATEST_STABLE_K8S_VERSION and USE_CNI=false.
