### PR TITLE
fix flannel image name and default version

### DIFF
--- a/docker-multinode/common.sh
+++ b/docker-multinode/common.sh
@@ -40,7 +40,7 @@ kube::multinode::main(){
 
   ETCD_VERSION=${ETCD_VERSION:-"3.0.4"}
 
-  FLANNEL_VERSION=${FLANNEL_VERSION:-"0.6.0"}
+  FLANNEL_VERSION=${FLANNEL_VERSION:-"v0.6.0"}
   FLANNEL_IPMASQ=${FLANNEL_IPMASQ:-"true"}
   FLANNEL_BACKEND=${FLANNEL_BACKEND:-"udp"}
   FLANNEL_NETWORK=${FLANNEL_NETWORK:-"10.1.0.0/16"}
@@ -149,7 +149,7 @@ kube::multinode::start_flannel() {
     --privileged \
     -v /dev/net:/dev/net \
     -v ${FLANNEL_SUBNET_DIR}:${FLANNEL_SUBNET_DIR} \
-    quay.io/coreos/flannel-${ARCH}:${FLANNEL_VERSION} \
+    quay.io/coreos/flannel:${FLANNEL_VERSION} \
     /opt/bin/flanneld \
       --etcd-endpoints=http://${MASTER_IP}:2379 \
       --ip-masq="${FLANNEL_IPMASQ}" \


### PR DESCRIPTION
Image quay.io/coreos/flannel-${ARCH} and version 0.6.0 not found in registry:

docker: Error: Status 403 trying to pull repository coreos/flannel-amd64: "{\"error\": \"Permission Denied\"}".

Correct image and tag: quay.io/coreos/flannel:v0.6.0
