### PR TITLE
docker-multinode - fixing flannel image used

### DIFF
--- a/docker-multinode/common.sh
+++ b/docker-multinode/common.sh
@@ -40,7 +40,7 @@ kube::multinode::main(){
 
   ETCD_VERSION=${ETCD_VERSION:-"3.0.4"}
 
-  FLANNEL_VERSION=${FLANNEL_VERSION:-"0.6.0"}
+  FLANNEL_VERSION=${FLANNEL_VERSION:-"0.5.0"}
   FLANNEL_IPMASQ=${FLANNEL_IPMASQ:-"true"}
   FLANNEL_BACKEND=${FLANNEL_BACKEND:-"udp"}
   FLANNEL_NETWORK=${FLANNEL_NETWORK:-"10.1.0.0/16"}
@@ -149,7 +149,7 @@ kube::multinode::start_flannel() {
     --privileged \
     -v /dev/net:/dev/net \
     -v ${FLANNEL_SUBNET_DIR}:${FLANNEL_SUBNET_DIR} \
-    quay.io/coreos/flannel-${ARCH}:${FLANNEL_VERSION} \
+    quay.io/coreos/flannel:${FLANNEL_VERSION} \
     /opt/bin/flanneld \
       --etcd-endpoints=http://${MASTER_IP}:2379 \
       --ip-masq="${FLANNEL_IPMASQ}" \


### PR DESCRIPTION
- The repo it is referring to no longer exist.  Changing the repo it moved to
- Moving the version back b/c it looks like the latest 0.6.0 version does not work as expected.  Version 0.5.0 works.
