### PR TITLE
Revert "Bump version of etcd and flannel"

### DIFF
--- a/docker-multinode/common.sh
+++ b/docker-multinode/common.sh
@@ -38,9 +38,10 @@ kube::multinode::main(){
   LATEST_STABLE_K8S_VERSION=$(curl -sSL "https://storage.googleapis.com/kubernetes-release/release/stable.txt")
   K8S_VERSION=${K8S_VERSION:-${LATEST_STABLE_K8S_VERSION}}
 
-  ETCD_VERSION=${ETCD_VERSION:-"3.0.4"}
+  # TODO: Update to 3.0.3
+  ETCD_VERSION=${ETCD_VERSION:-"2.2.5"}
 
-  FLANNEL_VERSION=${FLANNEL_VERSION:-"0.6.0"}
+  FLANNEL_VERSION=${FLANNEL_VERSION:-"0.5.5"}
   FLANNEL_IPMASQ=${FLANNEL_IPMASQ:-"true"}
   FLANNEL_BACKEND=${FLANNEL_BACKEND:-"udp"}
   FLANNEL_NETWORK=${FLANNEL_NETWORK:-"10.1.0.0/16"}
@@ -151,7 +152,7 @@ kube::multinode::start_flannel() {
     --privileged \
     -v /dev/net:/dev/net \
     -v ${FLANNEL_SUBNET_DIR}:${FLANNEL_SUBNET_DIR} \
-    quay.io/coreos/flannel-${ARCH}:${FLANNEL_VERSION} \
+    gcr.io/google_containers/flannel-${ARCH}:${FLANNEL_VERSION} \
     /opt/bin/flanneld \
       --etcd-endpoints=http://${MASTER_IP}:2379 \
       --ip-masq="${FLANNEL_IPMASQ}" \


### PR DESCRIPTION
Sorry for the mess everyone, seems like 
a) the image name was wrong (I recalled incorrectly) and 
b) the flannel team didn't build a working v0.6.0 image. We have to wait for newer versions.

Reverting to make it working again.
Reverts kubernetes/kube-deploy#197
