### PR TITLE
Add libvirt provider support

### DIFF
--- a/docker-multinode/test/README.md
+++ b/docker-multinode/test/README.md
@@ -29,6 +29,17 @@ vagrant up node
 vagrant up tests
 ```
 
+### Libvirt provider
+
+Test cluster can be started with libvirt provider. Go to [vagrant-libvirt-installation](https://github.com/vagrant-libvirt/vagrant-libvirt#installation)
+for further instruction.
+
+```
+vagrant up master --provider=libvirt
+vagrant up node --provider=libvirt
+vagrant up tests --provider=libvirt
+```
+
 ## Getting tests result
 
 When all VMs are up and running you can check e2e tests result. Logs are stored in file

--- a/docker-multinode/test/Vagrantfile
+++ b/docker-multinode/test/Vagrantfile
@@ -14,14 +14,19 @@
 
 def configure_vm(vm, **opts)
 
-    vm.box = opts.fetch(:box, "bento/ubuntu-16.04")
+    vm.box = opts.fetch(:box, "yk0/ubuntu-xenial")
     vm.network :private_network, ip: opts[:private_ip]
 
-    vm.provider "virtualbox" do |vb|
+    vm.provider :libvirt do |vb|
       vb.memory = 4096
       vb.cpus = 2
     end
-    
+
+    vm.provider :virtualbox do |vb|
+      vb.memory = 4096
+      vb.cpus = 2
+    end
+
     # Disable default share, because we dont use it
     vm.synced_folder ".", "/vagrant", disabled: true
     

--- a/docker-multinode/test/util.sh
+++ b/docker-multinode/test/util.sh
@@ -63,6 +63,8 @@ start_tests() {
   export KUBERNETES_CONFORMANCE_TEST=y
 
   # Compile minimal number of packages to run tests
+  apt-get update
+  apt-get install -y make gcc
   cd ${K8S_LOCATION_PATH}
   go get -u github.com/jteeuwen/go-bindata/go-bindata
   make all WHAT=cmd/kubectl


### PR DESCRIPTION
Flannel doesn't work well with Vagrant + Virtualbox. There is problem with services using https connection. This is the main reason of failing test:

```
[Fail] [k8s.io] Networking [It] should function for intra-pod communication [Conformance] 
/home/vagrant/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/networking.go:154
```

This PR adds support for libvirt provider.
