### PR TITLE
[WIP] use nsenter to lauch kubelet

### DIFF
--- a/docker-multinode/common.sh
+++ b/docker-multinode/common.sh
@@ -191,15 +191,19 @@ kube::multinode::start_k8s_master() {
     --name kube_kubelet_$(kube::helpers::small_sha) \
     ${KUBELET_MOUNTS} \
     gcr.io/google_containers/hyperkube-${ARCH}:${K8S_VERSION} \
-    /hyperkube kubelet \
-      --allow-privileged \
-      --api-servers=http://localhost:8080 \
-      --config=/etc/kubernetes/manifests-multi \
-      --cluster-dns=10.0.0.10 \
-      --cluster-domain=cluster.local \
-      ${CNI_ARGS} \
-      --hostname-override=${IP_ADDRESS} \
-      --v=2
+    /nsenter \
+      --target=1 \
+      --mount \
+      --wd=. \
+      -- ./hyperkube kubelet \
+          --allow-privileged \
+          --api-servers=http://localhost:8080 \
+          --config=etc/kubernetes/manifests-multi \
+          --cluster-dns=10.0.0.10 \
+          --cluster-domain=cluster.local \
+          ${CNI_ARGS} \
+          --hostname-override=${IP_ADDRESS} \
+          --v=2
 }
 
 # Start kubelet in a container, for a worker node

--- a/docker-multinode/common.sh
+++ b/docker-multinode/common.sh
@@ -82,7 +82,7 @@ kube::multinode::main(){
     ETCD_NET_PARAM="-p 2379:2379 -p 2380:2380 -p 4001:4001"
     CNI_ARGS="\
       --network-plugin=cni \
-      --network-plugin-dir=/etc/cni/net.d"
+      --network-plugin-dir=etc/cni/net.d"
   fi
 }
 
@@ -181,15 +181,12 @@ kube::multinode::start_flannel() {
 kube::multinode::start_k8s_master() {
   kube::log::status "Launching Kubernetes master components..."
 
-  kube::multinode::make_shared_kubelet_dir
-
   docker run -d \
     --net=host \
     --pid=host \
     --privileged \
     --restart=${RESTART_POLICY} \
     --name kube_kubelet_$(kube::helpers::small_sha) \
-    ${KUBELET_MOUNTS} \
     gcr.io/google_containers/hyperkube-${ARCH}:${K8S_VERSION} \
     /nsenter \
       --target=1 \


### PR DESCRIPTION
EXPERIMENTAL HACK: DON'T MERGE

PR could be base for fixing mounting issues like #196, #211, #182 

A lot of different network storage products exist on the market. In my understanding some have proprietary drivers and also kernel modules. 

One possible option to solve the problem seems not to containerize the drivers, but assume they are installed on host. With this PR I mount the host filesytem as root directory of the hyperkube container

I was curious a far I can get without much trouble. Actually, it works quite well. Everything seems to work. Even Dashboard is running.

@zreigz could you run e2e tests?

@huangfushun could you make a quick test if this hack maybe works out of the box?
