### PR TITLE
Fix killing docker bootstrap containers

### DIFF
--- a/docker-multinode/common.sh
+++ b/docker-multinode/common.sh
@@ -273,7 +273,7 @@ kube::multinode::turndown(){
     kube::log::status "Killing docker bootstrap..."
 
     # Kill the bootstrap docker daemon and it's containers
-    docker -H ${BOOTSTRAP_DOCKER_SOCK} rm -f $(docker -H ${BOOTSTRAP_DOCKER_SOCK} ps -q) >/dev/null 2>/dev/null
+    docker -H ${BOOTSTRAP_DOCKER_SOCK} rm -f $(docker -H ${BOOTSTRAP_DOCKER_SOCK} ps -a -q) >/dev/null 2>/dev/null
     kill ${DOCKER_BOOTSTRAP_PID}
   fi
 


### PR DESCRIPTION
This should resolve issues reported for flanneld and etcd which are started from docker-bootstrap
