### PR TITLE
Enable end-user customization of manifest files in docker-multinode

### DIFF
--- a/docker-multinode/README.md
+++ b/docker-multinode/README.md
@@ -38,7 +38,28 @@ v1.3.0 ships with support for amd64, arm and arm64. ppc64le isn't supported, due
 
 hyperkube was pushed for ppc64le at versions `v1.3.0-alpha.3` and `v1.3.0-alpha.4`, feel free to try them out, but there might be some unexpected bugs.
 
-### Options/configuration
+## Setup the master node
+
+The first step in the process is to initialize the master node.
+
+Clone the `kube-deploy` repo, and run [master.sh](master.sh) on the master machine _with root_:
+```console
+$ git clone https://github.com/kubernetes/kube-deploy
+$ cd kube-deploy/docker-multinode
+```
+
+Initialize the manifest files in `/etc/kubernetes`:
+```console
+$ ./init.sh
+```
+These files can be customized. However, in most cases this is not needed. Please note: up to version `v1.4.0` only the static manifests can be modified. Addons will be added in later releases.
+
+## Start master node
+
+Start the master:
+```console
+$ ./master.sh
+```
 
 The scripts will output something like this when starting:
 
@@ -57,17 +78,6 @@ The scripts will output something like this when starting:
 
 Each of these options are overridable by `export`ing the values before running the script.
 
-## Setup the master node
-
-The first step in the process is to initialize the master node.
-
-Clone the `kube-deploy` repo, and run [master.sh](master.sh) on the master machine _with root_:
-
-```console
-$ git clone https://github.com/kubernetes/kube-deploy
-$ cd kube-deploy/docker-multinode
-$ ./master.sh
-```
 
 First, the `bootstrap` docker daemon is started, then `etcd` and `flannel` are started as containers in the bootstrap daemon.
 Then, the main docker daemon is restarted, and this is an OS/distro-specific tasks, so if it doesn't work for your distro, feel free to contribute!

--- a/docker-multinode/common.sh
+++ b/docker-multinode/common.sh
@@ -84,6 +84,7 @@ kube::multinode::main(){
     -v /run:/run:rw \
     -v /var/lib/docker:/var/lib/docker:rw \
     ${KUBELET_MOUNT} \
+    -v /etc/kubernetes:/etc/kubernetes:rw \
     -v /var/log/containers:/var/log/containers:rw"
 
   # Paths
@@ -97,12 +98,12 @@ kube::multinode::main(){
       --network-plugin=cni \
       --network-plugin-dir=/etc/cni/net.d"
   fi
+
+  kube::helpers::parse_version ${K8S_VERSION}
 }
 
 # Ensure everything is OK, docker is running and we're root
 kube::multinode::log_variables() {
-
-  kube::helpers::parse_version ${K8S_VERSION}
 
   # Output the value of the variables
   kube::log::status "K8S_VERSION is set to: ${K8S_VERSION}"

--- a/docker-multinode/init.sh
+++ b/docker-multinode/init.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Source common.sh
+source $(dirname "${BASH_SOURCE}")/common.sh
+
+# init variables
+kube::multinode::main
+
+# copy configuration files from containter to host.
+rm -rf /etc/kubernetes
+mkdir -p /etc/kubernetes
+docker run -v /:/rootfs:rw gcr.io/google_containers/hyperkube-${ARCH}:${K8S_VERSION} \
+    cp -r /etc/kubernetes/manifests-multi /rootfs/etc/kubernetes/
+
+if [[ $((VERSION_MAJOR > 1)) == 1 || $((VERSION_MINOR > 4)) == 1 ]]; then
+  mkdir -p /etc/kubernetes/addons/multinode/
+  docker run -v /:/rootfs:rw gcr.io/google_containers/hyperkube-${ARCH}:${K8S_VERSION} \
+    cp -r  /etc/kubernetes/addons/multinode/ /rootfs/etc/kubernetes/addons/
+fi

--- a/docker-multinode/master.sh
+++ b/docker-multinode/master.sh
@@ -22,6 +22,17 @@ MASTER_IP=localhost
 
 kube::multinode::main
 
+# check if init script was run and matches the desired K8S version
+if [[ -z $(ls /etc/kubernetes/) ]]; then
+  echo "Please run init.sh to create manifest files in /etc/kubernetes."
+  exit 1
+fi
+K8S_VERSION_IN_MANIFEST=$(sed -n 's/.*hyperkube.*\(v.*\)\".*,/\1/p' /etc/kubernetes/manifests-multi/master-multi.json | head -1)
+if [[ $K8S_VERSION != $K8S_VERSION_IN_MANIFEST ]]; then
+  echo "Please run init.sh to create manifest files that match to the Kubernetes version $K8S_VERSION"
+  exit 1
+fi
+
 kube::multinode::log_variables
 
 kube::multinode::turndown


### PR DESCRIPTION
I added a simple way to customize the docker-multinode provisioning.

First, a new script copies the manifest files from container to host. The user can customize them as needed. 
Then these files are mounted when kubelet is started. The addon manager must be adapted as well to read from host. Separate PR https://github.com/kubernetes/kubernetes/pull/32578

I tried to make the UX simple. It seemed best to always read from host instead of providing a switch. 

Would fix

https://github.com/kubernetes/kube-deploy/issues/215

and beneficial to more issues like

 https://github.com/kubernetes/kube-deploy/issues/216
https://github.com/kubernetes/kube-deploy/issues/195
