### PR TITLE
imagebuilder: tag images

### DIFF
--- a/imagebuilder/aws.yaml
+++ b/imagebuilder/aws.yaml
@@ -1,2 +1,5 @@
 Cloud: aws
-TemplatePath: templates/1.3.yml
+TemplatePath: templates/1.4.yml
+Tags:
+  k8s.io/kernel: "4.4"
+  k8s.io/version: "1.4"

--- a/imagebuilder/main.go
+++ b/imagebuilder/main.go
@@ -52,6 +52,7 @@ var flagConfig = flag.String("config", "", "Config file to load")
 
 var flagUp = flag.Bool("up", true, "Set to create instance (if not found)")
 var flagBuild = flag.Bool("build", true, "Set to build image")
+var flagTag = flag.Bool("tag", true, "Set to tag image")
 var flagPublish = flag.Bool("publish", true, "Set to publish image")
 var flagReplicate = flag.Bool("replicate", true, "Set to copy the image to all regions")
 var flagDown = flag.Bool("down", true, "Set to shut down instance (if found)")
@@ -232,6 +233,31 @@ func main() {
 		if image == nil {
 			glog.Fatalf("image not found after build: %q", imageName)
 		}
+	}
+
+	if *flagTag {
+		if image == nil {
+			glog.Fatalf("image not found: %q", imageName)
+		}
+
+		glog.Infof("Tagging image %q", image)
+
+		tags := make(map[string]string)
+		for k, v := range config.Tags {
+			tags[k] = v
+		}
+
+		{
+			t := time.Now().UTC().Format(time.RFC3339)
+			tags["k8s.io/build"] = t
+		}
+
+		err = image.AddTags(tags)
+		if err != nil {
+			glog.Fatalf("error tagging image %q: %v", imageName, err)
+		}
+
+		glog.Infof("Tagged image %q", image)
 	}
 
 	if *flagPublish {

--- a/imagebuilder/pkg/imagebuilder/aws.go
+++ b/imagebuilder/pkg/imagebuilder/aws.go
@@ -515,6 +515,26 @@ func (i *AWSImage) EnsurePublic() error {
 	return i.ensurePublic()
 }
 
+// AddTags adds the specified tags on the image
+func (i *AWSImage) AddTags(tags map[string]string) error {
+	request := &ec2.CreateTagsInput{}
+	request.Resources = append(request.Resources, aws.String(i.imageID))
+	for k, v := range tags {
+		request.Tags = append(request.Tags, &ec2.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v),
+		})
+	}
+
+	glog.V(2).Infof("AWS CreateTags on image %v", i.imageID)
+	_, err := i.ec2.CreateTags(request)
+	if err != nil {
+		return fmt.Errorf("error tagging image %q: %v", i.imageID, err)
+	}
+
+	return err
+}
+
 func (i *AWSImage) waitStatusAvailable() error {
 	imageID := i.imageID
 

--- a/imagebuilder/pkg/imagebuilder/cloud.go
+++ b/imagebuilder/pkg/imagebuilder/cloud.go
@@ -18,5 +18,9 @@ type Instance interface {
 
 type Image interface {
 	EnsurePublic() error
+
+	// Adds the specified tags to the image
+	AddTags(tags map[string]string) error
+
 	ReplicateImage(makePublic bool) (map[string]Image, error)
 }

--- a/imagebuilder/pkg/imagebuilder/config.go
+++ b/imagebuilder/pkg/imagebuilder/config.go
@@ -11,6 +11,9 @@ type Config struct {
 	SSHUsername   string
 	SSHPublicKey  string
 	SSHPrivateKey string
+
+	// Tags to add to the image
+	Tags map[string]string
 }
 
 func (c *Config) InitDefaults() {

--- a/imagebuilder/pkg/imagebuilder/gce.go
+++ b/imagebuilder/pkg/imagebuilder/gce.go
@@ -291,7 +291,12 @@ func (i *GCEImage) EnsurePublic() error {
 	return fmt.Errorf("GCE does not currently support public images")
 }
 
-// ReplicateImage copies the image to all accessable GCE regions
+// AddTags adds the specified tags on the image
+func (i *GCEImage) AddTags(tags map[string]string) error {
+	return fmt.Errorf("Tagging of GCE images not yet implemented")
+}
+
+// ReplicateImage copies the image to all accessible GCE regions
 func (i *GCEImage) ReplicateImage(makePublic bool) (map[string]Image, error) {
 	if makePublic {
 		return nil, fmt.Errorf("GCE does not currently support public images")


### PR DESCRIPTION
By adding some image metadata, an enlightened tool can prompt to update
images or know the capabilities of an image (e.g. aufs vs overlay)
