### PR TITLE
imagebuilder: support building in non-us-east regions

### DIFF
--- a/imagebuilder/main.go
+++ b/imagebuilder/main.go
@@ -36,6 +36,7 @@ import (
 	"io/ioutil"
 	"k8s.io/kube-deploy/imagebuilder/pkg/imagebuilder"
 	"net/url"
+	"os"
 	"path"
 	"strings"
 )
@@ -279,8 +280,12 @@ func main() {
 }
 
 func initAWS() (*imagebuilder.AWSConfig, *imagebuilder.AWSCloud, error) {
+	region := os.Getenv("AWS_REGION")
+	if region == "" {
+		region = os.Getenv("AWS_DEFAULT_REGION")
+	}
 	awsConfig := &imagebuilder.AWSConfig{}
-	awsConfig.InitDefaults()
+	awsConfig.InitDefaults(region)
 	err := loadConfig(awsConfig, *flagConfig)
 	if err != nil {
 		glog.Exitf("Error loading AWS config: %v", err)

--- a/imagebuilder/pkg/imagebuilder/config.go
+++ b/imagebuilder/pkg/imagebuilder/config.go
@@ -1,5 +1,9 @@
 package imagebuilder
 
+import (
+	"github.com/golang/glog"
+)
+
 type Config struct {
 	Cloud         string
 	TemplatePath  string
@@ -41,12 +45,46 @@ type AWSConfig struct {
 	SecurityGroupID string
 }
 
-func (c *AWSConfig) InitDefaults() {
+func (c *AWSConfig) InitDefaults(region string) {
 	c.Config.InitDefaults()
-	c.Region = "us-east-1"
-	// Debian 8.4 us-east-1 from https://wiki.debian.org/Cloud/AmazonEC2Image/Jessie
-	c.ImageID = "ami-c8bda8a2"
 	c.InstanceType = "m3.medium"
+
+	if region == "" {
+		region = "us-east-1"
+	}
+
+	c.Region = region
+	switch c.Region {
+	case "cn-north-1":
+		glog.Infof("Detected cn-north-1 region")
+		// A slightly older image, but the newest one we have
+		c.ImageID = "ami-da69a1b7"
+
+	// Debian 8.4 images from https://wiki.debian.org/Cloud/AmazonEC2Image/Jessie
+	case "ap-northeast-1":
+		c.ImageID = "ami-d7d4c5b9"
+	case "ap-northeast-2":
+		c.ImageID = "ami-9a03caf4"
+	case "ap-southeast-1":
+		c.ImageID = "ami-73974210"
+	case "ap-southeast-2":
+		c.ImageID = "ami-09daf96a"
+	case "eu-central-1":
+		c.ImageID = "ami-ccc021a3"
+	case "eu-west-1":
+		c.ImageID = "ami-e079f893"
+	case "sa-east-1":
+		c.ImageID = "ami-d3ae21bf"
+	case "us-east-1":
+		c.ImageID = "ami-c8bda8a2"
+	case "us-west-1":
+		c.ImageID = "ami-45374b25"
+	case "us-west-2":
+		c.ImageID = "ami-98e114f8"
+
+	default:
+		glog.Warningf("Building in unknown region %q - will require specifying an image, may not work correctly")
+	}
 }
 
 type GCEConfig struct {


### PR DESCRIPTION
We can support building in regions other than us-east.  This is
important both for cn-north & govcloud, where we can't copy between
regions, but also for people that may not want their images to touch
us-east.
