### PR TITLE
Add the ability to specify a custom hyperkube base URL

### DIFF
--- a/docker-multinode/README.md
+++ b/docker-multinode/README.md
@@ -97,6 +97,17 @@ curl -sSL https://storage.googleapis.com/kubernetes-release/release/v[KUBECTL_VE
 chmod +x /usr/local/bin/kubectl
 ```
 
+## Customize images
+
+If you wish, you can customize the images that are used for Hyperkube and etcd. To do so set the
+`REGISTRY` variable to the repository URL for where your images will be stored. Under this URL you
+should provide:
+
+* An image named `hyperkube-$ARCH:$K8SVERSION`, where `$ARCH` and `$K8SVERSION` are
+  replaced with appropriate values for your install. For example: `hyperkube-amd64:v1.4.0`
+* An image named `etcd-$ARCH:$ETCD_VERSION`, where `$ARCH` and `$ETCD_VERSION` are replaced with
+  appropriate values for your install. For example: `etcd-amd64:3.0.4`
+
 ## Addons
 
 kube-dns and the dashboard are deployed automatically with v1.3.0

--- a/docker-multinode/common.sh
+++ b/docker-multinode/common.sh
@@ -133,7 +133,7 @@ kube::multinode::start_etcd() {
     --restart=${RESTART_POLICY} \
     ${ETCD_NET_PARAM} \
     -v /var/lib/kubelet/etcd:/var/etcd \
-    gcr.io/google_containers/etcd-${ARCH}:${ETCD_VERSION} \
+    ${REGISTRY}/etcd-${ARCH}:${ETCD_VERSION} \
     /usr/local/bin/etcd \
       --listen-client-urls=http://0.0.0.0:2379,http://0.0.0.0:4001 \
       --advertise-client-urls=http://localhost:2379,http://localhost:4001 \

--- a/docker-multinode/common.sh
+++ b/docker-multinode/common.sh
@@ -38,7 +38,7 @@ kube::multinode::main(){
 
   LATEST_STABLE_K8S_VERSION=$(curl -sSL "https://storage.googleapis.com/kubernetes-release/release/stable.txt")
   K8S_VERSION=${K8S_VERSION:-${LATEST_STABLE_K8S_VERSION}}
-  HYPERKUBE_BASE_URL=${HYPERKUBE_BASE_URL:-"gcr.io/google_containers/hyperkube-"}
+  REGISTRY=${REGISTRY:-"gcr.io/google_containers"}
 
   CURRENT_PLATFORM=$(kube::helpers::host_platform)
   ARCH=${ARCH:-${CURRENT_PLATFORM##*/}}
@@ -107,7 +107,7 @@ kube::multinode::log_variables() {
 
   # Output the value of the variables
   kube::log::status "K8S_VERSION is set to: ${K8S_VERSION}"
-  kube::log::status "HYPERKUBE_BASE_URL is set to: ${HYPERKUBE_BASE_URL}"
+  kube::log::status "REGISTRY is set to: ${REGISTRY}"
   kube::log::status "ETCD_VERSION is set to: ${ETCD_VERSION}"
   kube::log::status "FLANNEL_VERSION is set to: ${FLANNEL_VERSION}"
   kube::log::status "FLANNEL_IPMASQ is set to: ${FLANNEL_IPMASQ}"
@@ -210,7 +210,7 @@ kube::multinode::start_k8s_master() {
     --restart=${RESTART_POLICY} \
     --name kube_kubelet_$(kube::helpers::small_sha) \
     ${KUBELET_MOUNTS} \
-    ${HYPERKUBE_BASE_URL}${ARCH}:${K8S_VERSION} \
+    ${REGISTRY}/hyperkube-${ARCH}:${K8S_VERSION} \
     /hyperkube kubelet \
       --allow-privileged \
       --api-servers=http://localhost:8080 \
@@ -238,7 +238,7 @@ kube::multinode::start_k8s_worker() {
     --restart=${RESTART_POLICY} \
     --name kube_kubelet_$(kube::helpers::small_sha) \
     ${KUBELET_MOUNTS} \
-    ${HYPERKUBE_BASE_URL}${ARCH}:${K8S_VERSION} \
+    ${REGISTRY}/hyperkube-${ARCH}:${K8S_VERSION} \
     /hyperkube kubelet \
       --allow-privileged \
       --api-servers=http://${MASTER_IP}:8080 \
@@ -259,7 +259,7 @@ kube::multinode::start_k8s_worker_proxy() {
     --privileged \
     --name kube_proxy_$(kube::helpers::small_sha) \
     --restart=${RESTART_POLICY} \
-    ${HYPERKUBE_BASE_URL}${ARCH}:${K8S_VERSION} \
+    ${REGISTRY}/hyperkube-${ARCH}:${K8S_VERSION} \
     /hyperkube proxy \
         --master=http://${MASTER_IP}:8080 \
         --v=2

--- a/docker-multinode/common.sh
+++ b/docker-multinode/common.sh
@@ -38,6 +38,7 @@ kube::multinode::main(){
 
   LATEST_STABLE_K8S_VERSION=$(curl -sSL "https://storage.googleapis.com/kubernetes-release/release/stable.txt")
   K8S_VERSION=${K8S_VERSION:-${LATEST_STABLE_K8S_VERSION}}
+  HYPERKUBE_BASE_URL=${HYPERKUBE_BASE_URL:-"gcr.io/google_containers/hyperkube-"}
 
   CURRENT_PLATFORM=$(kube::helpers::host_platform)
   ARCH=${ARCH:-${CURRENT_PLATFORM##*/}}
@@ -106,6 +107,7 @@ kube::multinode::log_variables() {
 
   # Output the value of the variables
   kube::log::status "K8S_VERSION is set to: ${K8S_VERSION}"
+  kube::log::status "HYPERKUBE_BASE_URL is set to: ${HYPERKUBE_BASE_URL}"
   kube::log::status "ETCD_VERSION is set to: ${ETCD_VERSION}"
   kube::log::status "FLANNEL_VERSION is set to: ${FLANNEL_VERSION}"
   kube::log::status "FLANNEL_IPMASQ is set to: ${FLANNEL_IPMASQ}"
@@ -208,7 +210,7 @@ kube::multinode::start_k8s_master() {
     --restart=${RESTART_POLICY} \
     --name kube_kubelet_$(kube::helpers::small_sha) \
     ${KUBELET_MOUNTS} \
-    gcr.io/google_containers/hyperkube-${ARCH}:${K8S_VERSION} \
+    ${HYPERKUBE_BASE_URL}${ARCH}:${K8S_VERSION} \
     /hyperkube kubelet \
       --allow-privileged \
       --api-servers=http://localhost:8080 \
@@ -236,7 +238,7 @@ kube::multinode::start_k8s_worker() {
     --restart=${RESTART_POLICY} \
     --name kube_kubelet_$(kube::helpers::small_sha) \
     ${KUBELET_MOUNTS} \
-    gcr.io/google_containers/hyperkube-${ARCH}:${K8S_VERSION} \
+    ${HYPERKUBE_BASE_URL}${ARCH}:${K8S_VERSION} \
     /hyperkube kubelet \
       --allow-privileged \
       --api-servers=http://${MASTER_IP}:8080 \
@@ -257,7 +259,7 @@ kube::multinode::start_k8s_worker_proxy() {
     --privileged \
     --name kube_proxy_$(kube::helpers::small_sha) \
     --restart=${RESTART_POLICY} \
-    gcr.io/google_containers/hyperkube-${ARCH}:${K8S_VERSION} \
+    ${HYPERKUBE_BASE_URL}${ARCH}:${K8S_VERSION} \
     /hyperkube proxy \
         --master=http://${MASTER_IP}:8080 \
         --v=2


### PR DESCRIPTION
While using the docker-multinode deployment strategy it became evident
that it would be beneficial for us to periodically roll our own
hyperkube images with a few extras installed to make things like NFS
work properly for our kubelets. Therefore, this commit introduces the
new HYPERKUBE_BASE_URL setting that allows someone invoking the script
to specify a custom base URL for a hyperkube image.

Arch and Kubernetes version will still be added onto the end to form the
final URL for the image and tag.

As reported in kubernetes/kube-deploy#216
