### PR TITLE
Add missing apt-get update

### DIFF
--- a/docker-multinode/test/util.sh
+++ b/docker-multinode/test/util.sh
@@ -18,6 +18,7 @@ K8S_LOCATION_PATH=/home/vagrant/kubernetes
 
 # Install git and curl
 install_minimal_dependencies() {
+  apt-get update
   apt-get install -y git curl
 }
 


### PR DESCRIPTION
Without the additional `apt-get update` provisioning of VMs fails for me with: 

```
==> master: ca-certificates is already the newest version (20160104ubuntu1).
==> master: The following packages will be upgraded:
==> master:   apt-transport-https
==> master: 1 upgraded, 0 newly installed, 0 to remove and 51 not upgraded.
==> master: Need to get 25.7 kB of archives.
==> master: After this operation, 0 B of additional disk space will be used.
==> master: Err:1 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 apt-transport-https amd64 1.2.12~ubuntu16.04.1
==> master:   404  Not Found [IP: 91.189.91.26 80]
==> master: E: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/a/apt/apt-transport-https_1.2.12~ubuntu16.04.1_amd64.deb  404  Not Found [IP: 91.189.91.26 80]
==> master:
==> master: E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```