### PR TITLE
fix directory path and ensure region is set

### DIFF
--- a/imagebuilder/hack/setup-aws.sh
+++ b/imagebuilder/hack/setup-aws.sh
@@ -30,8 +30,9 @@ aws ec2 authorize-security-group-ingress  --group-id ${SG_ID} --protocol tcp --p
 
 IMGBUILDER_DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-cd ../$IMGBUILDER_DIRECTORY
+cd $IMGBUILDER_DIRECTORY/..
 
+export AWS_REGION=$(aws configure get region)
 imagebuilder --config aws.yaml --v=8
 
 echo We are done, and there be dragons!


### PR DESCRIPTION
* IMGBUILDER_DIRECTORY is an absolute path the .. needs to be at the end to go up a directory
* If the user is setting a region in ~/.aws/config the imagebuilder will break as it is only looking for the region in AWS_REGION and AWS_DEFAULT_REGION
