### PR TITLE
Add glusterfs support

### DIFF
--- a/imagebuilder/templates/1.2.yml
+++ b/imagebuilder/templates/1.2.yml
@@ -95,6 +95,8 @@ packages:
     # So we can install the latest awscli
     - python-pip
 {{ end }}
+    # Gluster dependencies in order to use the gluster volume
+    - glusterfs-client
 
 plugins:
 {{ if eq .Cloud "gce" }}

--- a/imagebuilder/templates/1.3.yml
+++ b/imagebuilder/templates/1.3.yml
@@ -95,6 +95,8 @@ packages:
     # So we can install the latest awscli
     - python-pip
 {{ end }}
+    # Gluster dependencies in order to use the gluster volume
+    - glusterfs-client
 
 plugins:
 {{ if eq .Cloud "gce" }}

--- a/imagebuilder/templates/1.4.yml
+++ b/imagebuilder/templates/1.4.yml
@@ -113,6 +113,9 @@ packages:
     - python-pip
 {{ end }}
 
+    # Gluster dependencies in order to use the gluster volume
+    - glusterfs-client
+
 plugins:
 {{ if eq .Cloud "gce" }}
   ntp:


### PR DESCRIPTION
In order to use the glusterfs volume plugin we need the gluster
client available on the instances we run Kubernetes on.