### PR TITLE
Add ENA support by updating dependencies

### DIFF
--- a/imagebuilder/pkg/imagebuilder/aws.go
+++ b/imagebuilder/pkg/imagebuilder/aws.go
@@ -143,8 +143,8 @@ func (a *AWSCloud) GetExtraEnv() (map[string]string, error) {
 		return nil, fmt.Errorf("error fetching EC2 credentials: %v", err)
 	}
 
-	env["AWS_ACCESS_KEY"] = creds.AccessKeyID
-	env["AWS_SECRET_KEY"] = creds.SecretAccessKey
+	env["AWS_ACCESS_KEY_ID"] = creds.AccessKeyID
+	env["AWS_SECRET_ACCESS_KEY"] = creds.SecretAccessKey
 
 	return env, nil
 }

--- a/imagebuilder/pkg/imagebuilder/aws.go
+++ b/imagebuilder/pkg/imagebuilder/aws.go
@@ -145,6 +145,7 @@ func (a *AWSCloud) GetExtraEnv() (map[string]string, error) {
 
 	env["AWS_ACCESS_KEY_ID"] = creds.AccessKeyID
 	env["AWS_SECRET_ACCESS_KEY"] = creds.SecretAccessKey
+	env["AWS_SESSION_TOKEN"] = creds.SessionToken
 
 	return env, nil
 }

--- a/imagebuilder/pkg/imagebuilder/config.go
+++ b/imagebuilder/pkg/imagebuilder/config.go
@@ -22,7 +22,7 @@ type Config struct {
 }
 
 func (c *Config) InitDefaults() {
-	c.BootstrapVZRepo = "https://github.com/justinsb/bootstrap-vz.git"
+	c.BootstrapVZRepo = "https://github.com/andsens/bootstrap-vz.git"
 	c.BootstrapVZBranch = "master"
 
 	c.SSHUsername = "admin"
@@ -32,7 +32,7 @@ func (c *Config) InitDefaults() {
 	setupCommands := []string{
 		"sudo apt-get update",
 		"sudo apt-get install --yes git python debootstrap python-pip kpartx parted",
-		"sudo pip install termcolor jsonschema fysom docopt pyyaml boto",
+		"sudo pip install termcolor jsonschema fysom docopt pyyaml boto boto3",
 	}
 	for _, cmd := range setupCommands {
 		c.SetupCommands = append(c.SetupCommands, strings.Split(cmd, " "))
@@ -65,27 +65,35 @@ func (c *AWSConfig) InitDefaults(region string) {
 		// A slightly older image, but the newest one we have
 		c.ImageID = "ami-da69a1b7"
 
-	// Debian 8.4 images from https://wiki.debian.org/Cloud/AmazonEC2Image/Jessie
+	// Debian 8.7 images from https://wiki.debian.org/Cloud/AmazonEC2Image/Jessie
 	case "ap-northeast-1":
-		c.ImageID = "ami-d7d4c5b9"
+		c.ImageID = "ami-dbc0bcbc"
 	case "ap-northeast-2":
-		c.ImageID = "ami-9a03caf4"
+		c.ImageID = "ami-6d8b5a03"
+	case "ap-south-1":
+		c.ImageID = "ami-9a83f5f5"
 	case "ap-southeast-1":
-		c.ImageID = "ami-73974210"
+		c.ImageID = "ami-0842e96b"
 	case "ap-southeast-2":
-		c.ImageID = "ami-09daf96a"
+		c.ImageID = "ami-881317eb"
+	case "ca-central-1":
+		c.ImageID = "ami-a1fe43c5"
 	case "eu-central-1":
-		c.ImageID = "ami-ccc021a3"
+		c.ImageID = "ami-5900cc36"
 	case "eu-west-1":
-		c.ImageID = "ami-e079f893"
+		c.ImageID = "ami-402f1a33"
+	case "eu-west-2":
+		c.ImageID = "ami-87848ee3"
 	case "sa-east-1":
-		c.ImageID = "ami-d3ae21bf"
+		c.ImageID = "ami-b256ccde"
 	case "us-east-1":
-		c.ImageID = "ami-c8bda8a2"
+		c.ImageID = "ami-b14ba7a7"
+	case "us-east-2":
+		c.ImageID = "ami-b2795cd7"
 	case "us-west-1":
-		c.ImageID = "ami-45374b25"
+		c.ImageID = "ami-94bdeef4"
 	case "us-west-2":
-		c.ImageID = "ami-98e114f8"
+		c.ImageID = "ami-221ea342"
 
 	default:
 		glog.Warningf("Building in unknown region %q - will require specifying an image, may not work correctly")

--- a/imagebuilder/templates/1.7.yml
+++ b/imagebuilder/templates/1.7.yml
@@ -143,8 +143,8 @@ plugins:
        - [ 'chroot', '{root}', 'apt-get', 'update' ]
        - [ 'chroot', '{root}', 'apt-get', 'install', '--yes', 'linux-image-k8s', 'linux-headers-k8s' ]
 
-       # Remove dkms ixgbevf driver
-       - [ 'chroot', '{root}', 'dkms', 'remove', 'ixgbevf/2.16.1', '--all' ]
+       # Remove supplied dkms ixgbevf driver so we fall back to more recent in kernel driver (despite lower version number)   
+       - [ 'chroot', '{root}', 'dkms', 'remove', 'ixgbevf/3.2.2', '--all' ]
 
        # We don't enable unattended upgrades - nodeup can always add it
        # but if we add it now, there's a race to turn it off


### PR DESCRIPTION
In light of https://github.com/kubernetes/kops/issues/1558, I tried adding ENA support to the KOPS images. In the end the easiest/best way in my eyes was just updating the underlying dependencies, where this was already included. This took included the following steps:
- Pull bootstrap-vz from upstream instead of from @justinsb's fork
- Add the new boto3 requirement
- Use the boto3 syntax for the AWS keys
- Update the version number of the ixgbevf to be removed - we prefer to use the in-kernel driver (see issue linked above)
- Use the latest debian 8.7 jessie images to start from, adding a few new regions while doing so

The upstream master already includes config to install the latest [AWS ENA drivers](https://github.com/andsens/bootstrap-vz/blob/master/bootstrapvz/providers/ec2/tasks/network.py#L126) and set the [--ena-support flag](https://github.com/andsens/bootstrap-vz/blob/master/bootstrapvz/providers/ec2/tasks/ami.py#L128) on the AMI 

An image built with this config from my account cant be found in us-east-1 as ami-7cdee507 (which should be public).

Output of relevant modules on a R4.large instance: 
```
admin:~$ sudo modinfo ena
filename:       /lib/modules/4.4.78-k8s/updates/dkms/ena.ko
version:        1.2.0g
license:        GPL
description:    Elastic Network Adapter (ENA)
author:         Amazon.com, Inc. or its affiliates
srcversion:     6FE02175A610B0C9723C28E
alias:          pci:v00001D0Fd0000EC21sv*sd*bc*sc*i*
alias:          pci:v00001D0Fd0000EC20sv*sd*bc*sc*i*
alias:          pci:v00001D0Fd00001EC2sv*sd*bc*sc*i*
alias:          pci:v00001D0Fd00000EC2sv*sd*bc*sc*i*
depends:
vermagic:       4.4.78-k8s SMP mod_unload modversions
parm:           debug:Debug level (0=none,...,16=all) (int)
admin:~$ sudo modinfo ixgbevf
filename:       /lib/modules/4.4.78-k8s/kernel/drivers/net/ethernet/intel/ixgbevf/ixgbevf.ko
version:        2.12.1-k
license:        GPL
description:    Intel(R) 10 Gigabit Virtual Function Network Driver
author:         Intel Corporation, <linux.nics@intel.com>
srcversion:     5AA37E00153CD4F19C91712
alias:          pci:v00008086d000015A8sv*sd*bc*sc*i*
alias:          pci:v00008086d00001565sv*sd*bc*sc*i*
alias:          pci:v00008086d00001515sv*sd*bc*sc*i*
alias:          pci:v00008086d000010EDsv*sd*bc*sc*i*
depends:
intree:         Y
vermagic:       4.4.78-k8s SMP mod_unload modversions
parm:           debug:Debug level (0=none,...,16=all) (int)
admin:~$ sudo ethtool -i eth0
driver: ena
version: 1.2.0g
firmware-version:
bus-info: 0000:00:03.0
supports-statistics: yes
supports-test: no
supports-eeprom-access: no
supports-register-dump: no
supports-priv-flags: no
```