### PR TITLE
Delete directories that only had placeholders to new repositories

### DIFF
--- a/min-turnup/README.md
+++ b/min-turnup/README.md
@@ -1,5 +1,0 @@
-# min-turnup
-
-*{concise,reliable,cross-platform} turnup of k8s clusters*
-
-min-turnup has been renamed and moved to [kubernetes/kubernetes-anywhere](https://github.com/kubernetes/kubernetes-anywhere).

--- a/protokube/README.md
+++ b/protokube/README.md
@@ -1,2 +1,0 @@
-Protokube has moved to [kops](https://github.com/kubernetes/kops)
-

--- a/upup/README.md
+++ b/upup/README.md
@@ -1,4 +1,0 @@
-The artisan installation tool formerly known as upup is now called kops: upup is so much more than just cluster up.
-
-Find it at [kops](https://github.com/kubernetes/kops)
-


### PR DESCRIPTION
Since those repositories are now well established and the forward links are no longer useful.