### PR TITLE
Remove k8s.io/kubernetes dependency from the API

### DIFF
--- a/cluster-api/api/machines/v1alpha1/types.go
+++ b/cluster-api/api/machines/v1alpha1/types.go
@@ -3,7 +3,6 @@ package v1alpha1
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/kubernetes/pkg/api"
 )
 
 const MachineResourcePlural = "machines"
@@ -82,7 +81,7 @@ type MachineSpec struct {
 type MachineStatus struct {
 	// If the corresponding Node exists, this will point to its object.
 	// +optional
-	NodeRef *api.ObjectReference `json:"nodeRef,omitempty"`
+	NodeRef *corev1.ObjectReference `json:"nodeRef,omitempty"`
 
 	// When was this status last observed
 	// +optional

--- a/cluster-api/api/machines/v1alpha1/zz_generated.deepcopy.go
+++ b/cluster-api/api/machines/v1alpha1/zz_generated.deepcopy.go
@@ -24,7 +24,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
-	api "k8s.io/kubernetes/pkg/api"
 	reflect "reflect"
 )
 
@@ -184,7 +183,7 @@ func (in *MachineStatus) DeepCopyInto(out *MachineStatus) {
 		if *in == nil {
 			*out = nil
 		} else {
-			*out = new(api.ObjectReference)
+			*out = new(v1.ObjectReference)
 			**out = **in
 		}
 	}


### PR DESCRIPTION
We should not rely on `k8s.io/kubernetes` at all.