### PR TITLE
Change api's group to cluster.k8s.io

### DIFF
--- a/cluster-api/api/cluster/v1alpha1/crd.go
+++ b/cluster-api/api/cluster/v1alpha1/crd.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	ClustersCRDGroup   = "cluster-api.k8s.io"
+	ClustersCRDGroup   = "cluster.k8s.io"
 	ClustersCRDPlural  = "clusters"
 	ClustersCRDVersion = "v1alpha1"
 	ClustersCRDName    = ClustersCRDPlural + "." + ClustersCRDGroup

--- a/cluster-api/api/cluster/v1alpha1/doc.go
+++ b/cluster-api/api/cluster/v1alpha1/doc.go
@@ -1,6 +1,6 @@
 // +k8s:deepcopy-gen=package,register
 // +k8s:openapi-gen=false
 
-// +groupName=cluster-api.k8s.io
+// +groupName=cluster.k8s.io
 
 package v1alpha1

--- a/cluster-api/api/machines/v1alpha1/crd.go
+++ b/cluster-api/api/machines/v1alpha1/crd.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	MachinesCRDGroup   = "cluster-api.k8s.io"
+	MachinesCRDGroup   = "cluster.k8s.io"
 	MachinesCRDPlural  = "machines"
 	MachinesCRDVersion = "v1alpha1"
 	MachinesCRDName    = MachinesCRDPlural + "." + MachinesCRDGroup

--- a/cluster-api/api/machines/v1alpha1/doc.go
+++ b/cluster-api/api/machines/v1alpha1/doc.go
@@ -1,6 +1,6 @@
 // +k8s:deepcopy-gen=package,register
 // +k8s:openapi-gen=false
 
-// +groupName=cluster-api.k8s.io
+// +groupName=cluster.k8s.io
 
 package v1alpha1

--- a/cluster-api/examples/gce-machine.yaml
+++ b/cluster-api/examples/gce-machine.yaml
@@ -1,4 +1,4 @@
-apiVersion: "cluster-api.k8s.io/v1alpha1"
+apiVersion: "cluster.k8s.io/v1alpha1"
 kind: Machine
 metadata:
   generateName: gce-machine-

--- a/cluster-api/examples/gce-machines-controller/gce-machine.yaml
+++ b/cluster-api/examples/gce-machines-controller/gce-machine.yaml
@@ -1,4 +1,4 @@
-apiVersion: "cluster-api.k8s.io/v1alpha1"
+apiVersion: "cluster.k8s.io/v1alpha1"
 kind: Machine
 metadata:
   generateName: gce-machine-

--- a/cluster-api/machines.yaml
+++ b/cluster-api/machines.yaml
@@ -1,5 +1,5 @@
 items:
-- apiVersion: "cluster-api.k8s.io/v1alpha1"
+- apiVersion: "cluster.k8s.io/v1alpha1"
   kind: Machine
   metadata:
     generateName: gce-master-
@@ -20,7 +20,7 @@ items:
         version: 1.12.0
     roles:
     - Master
-- apiVersion: "cluster-api.k8s.io/v1alpha1"
+- apiVersion: "cluster.k8s.io/v1alpha1"
   kind: Machine
   metadata:
     generateName: gce-node-


### PR DESCRIPTION
Rationale:
- tautology - we know that the group will hold API definitions.
- consistency - all other main k8s groups have a single word subdomain:
  storage.k8s.io, networking.k8s.io and etc..
- bug in [code-generator][0] that prevents clientset generation when
  hyphen is used in the last subdomain of the group.
- do it early that late.

Repercussions for this change will be that existing API resources needs
to be recreated - CRDs, Machines and Clusters.

[0]: https://github.com/kubernetes/code-generator/issues/22