### PR TITLE
Install machine controller on cluster creation (optional).

### DIFF
--- a/cluster-api/cloud/google/pods.go
+++ b/cluster-api/cloud/google/pods.go
@@ -1,0 +1,45 @@
+package google
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"text/template"
+)
+
+func CreateMachineControllerPod(token string) error {
+	tmpl, err := template.ParseFiles("cloud/google/pods/machine-controller.yaml")
+	if err != nil {
+		return err
+	}
+
+	type params struct {
+		Token string
+	}
+
+	var tmplBuf bytes.Buffer
+
+	err = tmpl.Execute(&tmplBuf, params{
+		Token: token,
+	})
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command("kubectl", "create", "-f", "-")
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		defer stdin.Close()
+		stdin.Write(tmplBuf.Bytes())
+	}()
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("couldn't create machine controller pod: %v, output: %v", err, out)
+	}
+	return nil
+}

--- a/cluster-api/cloud/google/pods/machine-controller.yaml
+++ b/cluster-api/cloud/google/pods/machine-controller.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ""
+  labels:
+    component: machinecontroller
+    tier: control-plane
+  name: machinecontroller
+  namespace: kube-system
+spec:
+  containers:
+    - name: machinecontroller
+      image: gcr.io/k8s-cluster-api/machinecontroller:0.1-alpha
+      args:
+        - --token={{ .Token }}
+        - --cloud=google
+        - --kubeconfig=/etc/kubernetes/admin.conf
+      volumeMounts:
+        - name: config
+          mountPath: /etc/kubernetes
+        - name: credentials
+          mountPath: /etc/credentials
+        - name: certs
+          mountPath: /etc/ssl/certs
+      env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/credentials/service-account.json
+  hostNetwork: true
+  nodeSelector:
+    node-role.kubernetes.io/master: ""
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+  - key: CriticalAddonsOnly
+    operator: Exists
+  - effect: NoExecute
+    key: node.alpha.kubernetes.io/notReady
+    operator: Exists
+  - effect: NoExecute
+    key: node.alpha.kubernetes.io/unreachable
+    operator: Exists
+  volumes:
+    - name: config
+      hostPath:
+        path: /etc/kubernetes
+    - name: credentials
+      secret:
+        secretName: machine-controller-credential
+    - name: certs
+      hostPath:
+        path: /etc/ssl/certs

--- a/cluster-api/cloud/google/serviceaccount.go
+++ b/cluster-api/cloud/google/serviceaccount.go
@@ -1,0 +1,50 @@
+package google
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+const (
+	MachineControllerServiceAccount = "k8s-machine-controller"
+	MachineControllerSecret = "machine-controller-credential"
+)
+
+// Creates a GCP service account for the machine controller, granted the
+// permissions to manage compute instances, and stores its credentials as a
+// Kubernetes secret.
+func CreateMachineControllerServiceAccount(project string) error {
+	// TODO: use real go bindings
+	err := run("gcloud", "--project", project, "iam", "service-accounts", "create", "--display-name=k8s machines controller", MachineControllerServiceAccount)
+	if err != nil {
+		return fmt.Errorf("couldn't create service account: %v", err)
+	}
+
+	email := fmt.Sprintf("%s@%s.iam.gserviceaccount.com", MachineControllerServiceAccount, project)
+	localFile := MachineControllerServiceAccount + "-key.json"
+
+	err = run("gcloud", "projects", "add-iam-policy-binding", project, "--member=serviceAccount:" + email, "--role=roles/compute.instanceAdmin.v1")
+	if err != nil {
+		return fmt.Errorf("couldn't grant permissions to service account: %v", err)
+	}
+
+	err = run("gcloud", "--project", project, "iam", "service-accounts", "keys", "create", localFile, "--iam-account", email)
+	if err != nil {
+		return fmt.Errorf("couldn't create service account key: %v", err)
+	}
+
+	err = run("kubectl", "create", "secret", "generic", "-n", "kube-system", MachineControllerSecret, "--from-file=service-account.json=" + localFile)
+	if err != nil {
+		return fmt.Errorf("couldn't import service account key as credential: %v", err)
+	}
+
+	return nil
+}
+
+func run(cmd string, args ...string) error {
+	c := exec.Command(cmd, args...)
+	if out, err := c.CombinedOutput(); err != nil {
+		return fmt.Errorf("error: %v, output: %s", err, string(out))
+	}
+	return nil
+}

--- a/cluster-api/cmd/create.go
+++ b/cluster-api/cmd/create.go
@@ -1,17 +1,17 @@
 package cmd
 
 import (
-
 	"github.com/kris-nova/kubicorn/cutil/logger"
 	"github.com/spf13/cobra"
-	"os"
-	_ "k8s.io/kube-deploy/cluster-api/deploy"
 	"k8s.io/kube-deploy/cluster-api/deploy"
+	_ "k8s.io/kube-deploy/cluster-api/deploy"
+	"os"
 )
 
 type CreateOptions struct {
-	Cluster string
-	Machine string
+	Cluster                 string
+	Machine                 string
+	EnableMachineController bool
 }
 
 var co = &CreateOptions{}
@@ -52,7 +52,7 @@ func RunCreate(co *CreateOptions) error {
 
 	//logger.Info("Parsing done [%s]", machines)
 
-	if err = deploy.CreateCluster(cluster, machines); err != nil {
+	if err = deploy.CreateCluster(cluster, machines, co.EnableMachineController); err != nil {
 		return err
 	}
 	return nil
@@ -61,6 +61,7 @@ func RunCreate(co *CreateOptions) error {
 func init() {
 	createCmd.Flags().StringVarP(&co.Cluster, "cluster", "c", "", "cluster yaml file")
 	createCmd.Flags().StringVarP(&co.Machine, "machines", "m", "", "machine yaml file")
+	createCmd.Flags().BoolVarP(&co.EnableMachineController, "enable-machine-controller", "e", false, "whether or not to start the machine controller")
 
 	RootCmd.AddCommand(createCmd)
 }


### PR DESCRIPTION
This is hidden behind a new `--enable-machine-controller` flag while I work out any kinks, and only works on GCE. It creates a service account, gives it the `compute.instanceAdmin.v1` role, imports its credentials into a cluster secret, and creates a pod on the master for the machine controller.