### PR TITLE
Have the machine-controller skip masters (for now).

### DIFF
--- a/cluster-api/machine-controller/Makefile
+++ b/cluster-api/machine-controller/Makefile
@@ -1,6 +1,6 @@
 PROJECT=k8s-cluster-api
 NAME=machine-controller
-VERSION=0.1
+VERSION=0.2
 
 staticbuild:
 	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' .

--- a/cluster-api/machine-controller/controller/client.go
+++ b/cluster-api/machine-controller/controller/client.go
@@ -17,12 +17,12 @@ limitations under the License.
 package controller
 
 import (
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 
 	machinesv1 "k8s.io/kube-deploy/cluster-api/api/machines/v1alpha1"
 )

--- a/cluster-api/machine-controller/controller/configuration.go
+++ b/cluster-api/machine-controller/controller/configuration.go
@@ -21,8 +21,8 @@ import (
 )
 
 type Configuration struct {
-	Kubeconfig string
-	Cloud string
+	Kubeconfig   string
+	Cloud        string
 	KubeadmToken string
 }
 

--- a/cluster-api/machine-controller/controller/machineactuator.go
+++ b/cluster-api/machine-controller/controller/machineactuator.go
@@ -17,11 +17,11 @@ limitations under the License.
 package controller
 
 import (
-	"github.com/golang/glog"
+	"fmt"
 
+	"github.com/golang/glog"
 	machinesv1 "k8s.io/kube-deploy/cluster-api/api/machines/v1alpha1"
 	"k8s.io/kube-deploy/cluster-api/cloud"
-	"fmt"
 	"k8s.io/kube-deploy/cluster-api/cloud/google"
 )
 
@@ -37,20 +37,20 @@ func newMachineActuator(cloud string, kubeadmToken string, masterIP string) (clo
 }
 
 // An actuator that just logs instead of doing anything.
-type loggingMachineActuator struct {}
+type loggingMachineActuator struct{}
 
-func (a loggingMachineActuator) Create(machine *machinesv1.Machine) error{
+func (a loggingMachineActuator) Create(machine *machinesv1.Machine) error {
 	glog.Infof("actuator received create: %s\n", machine.ObjectMeta.Name)
 	return nil
 }
 
-func (a loggingMachineActuator) Delete(machine *machinesv1.Machine) error{
+func (a loggingMachineActuator) Delete(machine *machinesv1.Machine) error {
 	glog.Infof("actuator received delete: %s\n", machine.ObjectMeta.Name)
 	return nil
 
 }
 
-func (a loggingMachineActuator) Get(name string) (*machinesv1.Machine, error){
+func (a loggingMachineActuator) Get(name string) (*machinesv1.Machine, error) {
 	glog.Infof("actuator received get %s\n", name)
 	return &machinesv1.Machine{}, nil
 }

--- a/cluster-api/machine-controller/main.go
+++ b/cluster-api/machine-controller/main.go
@@ -17,9 +17,9 @@ limitations under the License.
 package main
 
 import (
+	goflag "flag"
 	"fmt"
 	"os"
-	goflag "flag"
 
 	"github.com/spf13/pflag"
 


### PR DESCRIPTION
For the initial prototype, we've agreed to have the client-side creation tool provision the master host, and to not support multiple master hosts in the cluster (for now). Because of this, the machine-controller should skip Machines with a Master role (for now).

Also, run the code through gofmt.