### PR TITLE
Add make target for fixing image permissions.

### DIFF
--- a/cluster-api/machine-controller/Makefile
+++ b/cluster-api/machine-controller/Makefile
@@ -11,4 +11,7 @@ image: staticbuild
 push: image
 	gcloud docker -- push "gcr.io/$(PROJECT)/$(NAME):$(VERSION)"
 
-.PHONY: image push staticbuild
+fix-image-permissions:
+	gsutil -m acl ch -r -u AllUsers:READ gs://artifacts.$(PROJECT).appspot.com
+
+.PHONY: image push staticbuild fix-image-permissions


### PR DESCRIPTION
Until we fix the image bucket defaults, we can run this target after pushing new images to make sure they are publicly readable.