### PR TITLE
Honor kubelet version when creating GCE VMs.

### DIFF
--- a/cluster-api/cloud/google/machineactuator.go
+++ b/cluster-api/cloud/google/machineactuator.go
@@ -71,7 +71,7 @@ func (gce *GCEClient) Create(machine *machinesv1.Machine) error {
 		return err
 	}
 
-	startupScript := nodeStartupScript(gce.kubeadmToken, gce.masterIP)
+	startupScript := nodeStartupScript(gce.kubeadmToken, gce.masterIP, machine.Spec.Versions.Kubelet)
 
 	op, err := gce.service.Instances.Insert(config.Project, config.Zone, &compute.Instance{
 		Name:        machine.ObjectMeta.Name,

--- a/cluster-api/cloud/google/pods/machine-controller.yaml
+++ b/cluster-api/cloud/google/pods/machine-controller.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   containers:
     - name: machine-controller
-      image: gcr.io/k8s-cluster-api/machine-controller:0.1-alpha
+      image: gcr.io/k8s-cluster-api/machine-controller:0.3
       args:
         - --token={{ .Token }}
         - --cloud=google

--- a/cluster-api/cloud/google/templates.go
+++ b/cluster-api/cloud/google/templates.go
@@ -28,9 +28,9 @@ func sanitizeMasterIP(ip string) string {
 }
 
 
-func nodeStartupScript(kubeadmToken	string, masterIP string) string {
+func nodeStartupScript(kubeadmToken, masterIP, kubeletVersion string) string {
 	mip := sanitizeMasterIP(masterIP)
-	return fmt.Sprintf(nodeStartupTemplate, kubeadmToken, mip)
+	return fmt.Sprintf(nodeStartupTemplate, kubeadmToken, mip, kubeletVersion)
 }
 
 const nodeStartupTemplate = `
@@ -42,6 +42,7 @@ set -x
 (
 TOKEN=%s
 MASTER=%s
+KUBELET_VERSION=%s-00
 
 apt-get update
 apt-get install -y apt-transport-https
@@ -62,7 +63,7 @@ cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
 deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF
 apt-get update
-apt-get install -y kubelet kubeadm kubectl kubernetes-cni
+apt-get install -y kubelet=${KUBELET_VERSION} kubeadm=${KUBELET_VERSION}
 
 kubeadm join --token "${TOKEN}" "${MASTER}:443" --skip-preflight-checks
 

--- a/cluster-api/machine-controller/Makefile
+++ b/cluster-api/machine-controller/Makefile
@@ -1,6 +1,6 @@
 PROJECT=k8s-cluster-api
 NAME=machine-controller
-VERSION=0.2
+VERSION=0.3
 
 staticbuild:
 	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' .


### PR DESCRIPTION
Part of https://github.com/kubernetes/kube-deploy/issues/352.