### PR TITLE
Have nodes annotate themselves with machine name.

### DIFF
--- a/cluster-api/cloud/google/machineactuator.go
+++ b/cluster-api/cloud/google/machineactuator.go
@@ -71,7 +71,7 @@ func (gce *GCEClient) Create(machine *machinesv1.Machine) error {
 		return err
 	}
 
-	startupScript := nodeStartupScript(gce.kubeadmToken, gce.masterIP, machine.Spec.Versions.Kubelet)
+	startupScript := nodeStartupScript(gce.kubeadmToken, gce.masterIP, machine.ObjectMeta.Name, machine.Spec.Versions.Kubelet)
 
 	op, err := gce.service.Instances.Insert(config.Project, config.Zone, &compute.Instance{
 		Name:        machine.ObjectMeta.Name,

--- a/cluster-api/cloud/google/pods/machine-controller.yaml
+++ b/cluster-api/cloud/google/pods/machine-controller.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   containers:
     - name: machine-controller
-      image: gcr.io/k8s-cluster-api/machine-controller:0.3
+      image: gcr.io/k8s-cluster-api/machine-controller:0.4
       args:
         - --token={{ .Token }}
         - --cloud=google

--- a/cluster-api/machine-controller/Makefile
+++ b/cluster-api/machine-controller/Makefile
@@ -1,6 +1,6 @@
 PROJECT=k8s-cluster-api
 NAME=machine-controller
-VERSION=0.3
+VERSION=0.4
 
 staticbuild:
 	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' .


### PR DESCRIPTION
This will make it easier for the machine-controller to link Machine and Node objects together, even if the names don't match (like if we choose to create-then-delete VMs on updates).

Part of https://github.com/kubernetes/kube-deploy/issues/348.