### PR TITLE
Fix our example yaml files.

### DIFF
--- a/cluster-api/cluster.yaml
+++ b/cluster-api/cluster.yaml
@@ -5,5 +5,5 @@ spec:
         "apiVersion": "gceproviderconfig/v1alpha1",
         "kind": "GCEProviderConfig",
         "project": "kumaraji-gke-dev",
-        "zone": "us-central1-f",
+        "zone": "us-central1-f"
       }

--- a/cluster-api/machines.yaml
+++ b/cluster-api/machines.yaml
@@ -2,7 +2,7 @@ items:
 - apiVersion: "cluster-api.k8s.io/v1alpha1"
   kind: Machine
   metadata:
-    name: master-1
+    name: gce-master-1
     generateName: gce-master-
     labels:
       set: master


### PR DESCRIPTION
The JSON `providerConfig` embedded in `cluster.yaml` failed decoding, and the `machines.yaml` master `name` didn't match its `generateName`.