### PR TITLE
Get service account projects from Machines, not Cluster.

### DIFF
--- a/cluster-api/cloud/google/serviceaccount.go
+++ b/cluster-api/cloud/google/serviceaccount.go
@@ -23,14 +23,19 @@ import (
 
 const (
 	MachineControllerServiceAccount = "k8s-machine-controller"
-	MachineControllerSecret = "machine-controller-credential"
+	MachineControllerSecret         = "machine-controller-credential"
 )
 
 // Creates a GCP service account for the machine controller, granted the
 // permissions to manage compute instances, and stores its credentials as a
 // Kubernetes secret.
-func CreateMachineControllerServiceAccount(project string) error {
+func CreateMachineControllerServiceAccount(projects []string) error {
 	// TODO: use real go bindings
+
+	// The service account needs to be created in a single project, so just
+	// use the first one, but grant permission to all projects in the list.
+	project := projects[0]
+
 	err := run("gcloud", "--project", project, "iam", "service-accounts", "create", "--display-name=k8s machines controller", MachineControllerServiceAccount)
 	if err != nil {
 		return fmt.Errorf("couldn't create service account: %v", err)
@@ -39,9 +44,11 @@ func CreateMachineControllerServiceAccount(project string) error {
 	email := fmt.Sprintf("%s@%s.iam.gserviceaccount.com", MachineControllerServiceAccount, project)
 	localFile := MachineControllerServiceAccount + "-key.json"
 
-	err = run("gcloud", "projects", "add-iam-policy-binding", project, "--member=serviceAccount:" + email, "--role=roles/compute.instanceAdmin.v1")
-	if err != nil {
-		return fmt.Errorf("couldn't grant permissions to service account: %v", err)
+	for _, project := range projects {
+		err = run("gcloud", "projects", "add-iam-policy-binding", project, "--member=serviceAccount:"+email, "--role=roles/compute.instanceAdmin.v1")
+		if err != nil {
+			return fmt.Errorf("couldn't grant permissions to service account: %v", err)
+		}
 	}
 
 	err = run("gcloud", "--project", project, "iam", "service-accounts", "keys", "create", localFile, "--iam-account", email)
@@ -49,7 +56,7 @@ func CreateMachineControllerServiceAccount(project string) error {
 		return fmt.Errorf("couldn't create service account key: %v", err)
 	}
 
-	err = run("kubectl", "create", "secret", "generic", "-n", "kube-system", MachineControllerSecret, "--from-file=service-account.json=" + localFile)
+	err = run("kubectl", "create", "secret", "generic", "-n", "kube-system", MachineControllerSecret, "--from-file=service-account.json="+localFile)
 	if err != nil {
 		return fmt.Errorf("couldn't import service account key as credential: %v", err)
 	}

--- a/cluster-api/cloud/machineactuator.go
+++ b/cluster-api/cloud/machineactuator.go
@@ -27,5 +27,10 @@ type MachineActuator interface {
 	Get(string) (*clusterv1.Machine, error)
 	GetIP(machine *clusterv1.Machine) (string, error)
 	GetKubeConfig(master *clusterv1.Machine) (string, error)
-	CreateMachineController(cluster *clusterv1.Cluster) error
+
+	// Create and start the machine controller. The list of initial
+	// machines don't have to be reconciled as part of this function, but
+	// are provided in case the function wants to refer to them (and their
+	// ProviderConfigs) to know how to configure the machine controller.
+	CreateMachineController(initialMachines []*clusterv1.Machine) error
 }

--- a/cluster-api/cluster.yaml
+++ b/cluster-api/cluster.yaml
@@ -3,7 +3,5 @@ spec:
     providerConfig: >
       {
         "apiVersion": "gceproviderconfig/v1alpha1",
-        "kind": "GCEProviderConfig",
-        "project": "kumaraji-gke-dev",
-        "zone": "us-central1-f"
+        "kind": "GCEProviderConfig"
       }

--- a/cluster-api/cmd/root.go
+++ b/cluster-api/cmd/root.go
@@ -63,7 +63,7 @@ func parseClusterYaml(file string) (*clusterv1.Cluster, error) {
 	return cluster, nil
 }
 
-func parseMachinesYaml(file string) ([]clusterv1.Machine, error) {
+func parseMachinesYaml(file string) ([]*clusterv1.Machine, error) {
 	bytes, err := ioutil.ReadFile(file)
 	if err != nil {
 		return nil, err
@@ -74,5 +74,11 @@ func parseMachinesYaml(file string) ([]clusterv1.Machine, error) {
 	if err != nil {
 		return nil, err
 	}
-	return machines.Items, nil
+
+	// Convert to list of pointers
+	var ret []*clusterv1.Machine
+	for _, machine := range machines.Items {
+		ret = append(ret, machine.DeepCopy())
+	}
+	return ret, nil
 }

--- a/cluster-api/deploy/deploy.go
+++ b/cluster-api/deploy/deploy.go
@@ -35,20 +35,19 @@ type deployer struct {
 
 func NewDeployer() *deployer {
 	token := util.RandomToken()
-	a, err := google.NewMachineActuator(token, "mastetrip")
+	a, err := google.NewMachineActuator(token, "masterip")
 	if err != nil {
 		log.Fatal(err)
 	}
 	return &deployer{
 		token:    token,
-		masterIP: "mastetrip",
+		masterIP: "masterip",
 		actuator: a,
 	}
 }
 
 // CreateCluster uses GCP APIs to create cluster
-func (d *deployer) CreateCluster(c *clusterv1.Cluster, machines []clusterv1.Machine, enableMachineController bool) error {
-
+func (d *deployer) CreateCluster(c *clusterv1.Cluster, machines []*clusterv1.Machine, enableMachineController bool) error {
 	master := util.GetMaster(machines)
 	if master == nil {
 		return fmt.Errorf("error creating master vm, no master found")
@@ -72,7 +71,7 @@ func (d *deployer) CreateCluster(c *clusterv1.Cluster, machines []clusterv1.Mach
 	}
 
 	if enableMachineController {
-		if err := d.actuator.CreateMachineController(c); err != nil {
+		if err := d.actuator.CreateMachineController(machines); err != nil {
 			return err
 		}
 	}

--- a/cluster-api/deploy/deploy_helper.go
+++ b/cluster-api/deploy/deploy_helper.go
@@ -39,7 +39,8 @@ const (
 	DeleteSleepSeconds     = 5
 )
 
-func (d *deployer) createMachineCRD(machines []clusterv1.Machine) error {
+func (d *deployer) createMachineCRD(machines []*clusterv1.Machine) error {
+	log.Print("Creating Machines CRD...\n")
 	config, err := getConfig()
 	cs, err := clientset(config)
 	if err != nil {
@@ -49,6 +50,7 @@ func (d *deployer) createMachineCRD(machines []clusterv1.Machine) error {
 	success := false
 	for i := 0; i <= RetryAttempts; i++ {
 		if _, err = clusterv1.CreateMachinesCRD(cs); err != nil {
+			log.Printf("Failure creating Machines CRD (will retry): %v\n", err)
 			time.Sleep(time.Duration(SleepSecondsPerAttempt) * time.Second)
 			continue
 		}
@@ -67,7 +69,7 @@ func (d *deployer) createMachineCRD(machines []clusterv1.Machine) error {
 	}
 
 	for _, machine := range machines {
-		_, err = client.Machines().Create(&machine)
+		_, err = client.Machines().Create(machine)
 		if err != nil {
 			return err
 		}

--- a/cluster-api/machine-controller/controller/machineactuator.go
+++ b/cluster-api/machine-controller/controller/machineactuator.go
@@ -65,7 +65,7 @@ func (a loggingMachineActuator) GetKubeConfig(master *clusterv1.Machine) (string
 	return "", nil
 }
 
-func (a loggingMachineActuator) CreateMachineController(cluster *clusterv1.Cluster) error {
-	glog.Infof("actuator received CreateMachineController: %s\n", cluster.ObjectMeta.Name)
+func (a loggingMachineActuator) CreateMachineController(machines []*clusterv1.Machine) error {
+	glog.Infof("actuator received CreateMachineController: %q\n", machines)
 	return nil
 }

--- a/cluster-api/util/util.go
+++ b/cluster-api/util/util.go
@@ -63,10 +63,10 @@ func IsMaster(machine *clusterv1.Machine) bool {
 	return Contains(TypeMaster, machine.Spec.Roles)
 }
 
-func GetMaster(machines []clusterv1.Machine) *clusterv1.Machine {
+func GetMaster(machines []*clusterv1.Machine) *clusterv1.Machine {
 	for _, machine := range machines {
-		if IsMaster(&machine) {
-			return &machine
+		if IsMaster(machine) {
+			return machine
 		}
 	}
 	return nil


### PR DESCRIPTION
When creating a service account for the machine-controller, rather than requiring a `Project` be defined in the `Cluster` object `ProviderConfig`, instead look at the `ProviderConfig`s of all of the `Machine` objects, and add permissions for them all for the service account.

Also, change from using `[]Machine` to `[]*Machine` most places to play nicely with other code.