### PR TITLE
Have the master annotate itself as well.

### DIFF
--- a/cluster-api/cloud/google/machineactuator.go
+++ b/cluster-api/cloud/google/machineactuator.go
@@ -96,7 +96,7 @@ func (gce *GCEClient) Create(machine *clusterv1.Machine) error {
 
 	var startupScript string
 	if util.IsMaster(machine) {
-		startupScript = masterStartupScript(gce.kubeadmToken, "443")
+		startupScript = masterStartupScript(gce.kubeadmToken, "443", machine.ObjectMeta.Name)
 	} else {
 		startupScript = nodeStartupScript(gce.kubeadmToken, gce.masterIP, machine.ObjectMeta.Name, machine.Spec.Versions.Kubelet)
 	}


### PR DESCRIPTION
The node was already self-annotating during startup with its corresponding Machine name so that the machines-controller could more easily link the two objects, but the master wasn't.