### PR TITLE
Actually honor kubelet/control plane versions when creating masters.

### DIFF
--- a/cluster-api/cloud/google/machineactuator.go
+++ b/cluster-api/cloud/google/machineactuator.go
@@ -96,7 +96,15 @@ func (gce *GCEClient) Create(machine *clusterv1.Machine) error {
 
 	var startupScript string
 	if util.IsMaster(machine) {
-		startupScript = masterStartupScript(gce.kubeadmToken, "443", machine.ObjectMeta.Name)
+		kubeletVersion := machine.Spec.Versions.Kubelet
+		controlPlaneVersion := machine.Spec.Versions.ControlPlane
+		if kubeletVersion == "" {
+			return fmt.Errorf("invalid master configuration: missing Machine.Spec.Versions.Kubelet")
+		}
+		if controlPlaneVersion == "" {
+			return fmt.Errorf("invalid master configuration: missing Machine.Spec.Versions.ControlPlane")
+		}
+		startupScript = masterStartupScript(gce.kubeadmToken, "443", machine.ObjectMeta.Name, kubeletVersion, controlPlaneVersion)
 	} else {
 		startupScript = nodeStartupScript(gce.kubeadmToken, gce.masterIP, machine.ObjectMeta.Name, machine.Spec.Versions.Kubelet)
 	}

--- a/cluster-api/machines.yaml
+++ b/cluster-api/machines.yaml
@@ -18,6 +18,7 @@ items:
       }
     versions:
       kubelet: 1.7.4
+      controlPlane: 1.7.4
       containerRuntime:
         name: docker
         version: 1.12.0


### PR DESCRIPTION
Previously, they were using a fixed version of kubeadm, the latest version of kubelet, and the default version of the control plane.