### PR TITLE
Watch nodes and link them to machines.

### DIFF
--- a/cluster-api/api/cluster/v1alpha1/types.go
+++ b/cluster-api/api/cluster/v1alpha1/types.go
@@ -21,7 +21,6 @@ package v1alpha1 // import "k8s.io/kube-deploy/cluster-api/api/cluster/v1alpha1"
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/kubernetes/pkg/api"
 )
 
 // deepcopy-gen can be installed with:
@@ -203,7 +202,7 @@ type MachineSpec struct {
 type MachineStatus struct {
 	// If the corresponding Node exists, this will point to its object.
 	// +optional
-	NodeRef *api.ObjectReference `json:"nodeRef,omitempty"`
+	NodeRef *corev1.ObjectReference `json:"nodeRef,omitempty"`
 
 	// When was this status last observed
 	// +optional

--- a/cluster-api/api/cluster/v1alpha1/zz_generated.deepcopy.go
+++ b/cluster-api/api/cluster/v1alpha1/zz_generated.deepcopy.go
@@ -24,7 +24,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
-	api "k8s.io/kubernetes/pkg/api"
 	reflect "reflect"
 )
 
@@ -341,7 +340,7 @@ func (in *MachineStatus) DeepCopyInto(out *MachineStatus) {
 		if *in == nil {
 			*out = nil
 		} else {
-			*out = new(api.ObjectReference)
+			*out = new(v1.ObjectReference)
 			**out = **in
 		}
 	}

--- a/cluster-api/cloud/google/pods/machine-controller.yaml
+++ b/cluster-api/cloud/google/pods/machine-controller.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   containers:
     - name: machine-controller
-      image: gcr.io/k8s-cluster-api/machine-controller:0.4
+      image: gcr.io/k8s-cluster-api/machine-controller:0.5
       args:
         - --token={{ .Token }}
         - --cloud=google

--- a/cluster-api/machine-controller/Makefile
+++ b/cluster-api/machine-controller/Makefile
@@ -1,6 +1,6 @@
 PROJECT=k8s-cluster-api
 NAME=machine-controller
-VERSION=0.4
+VERSION=0.5
 
 staticbuild:
 	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' .

--- a/cluster-api/machine-controller/controller/nodewatcher.go
+++ b/cluster-api/machine-controller/controller/nodewatcher.go
@@ -1,0 +1,196 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	"github.com/golang/glog"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clientcmd"
+	clusterapiclient "k8s.io/kube-deploy/cluster-api/client"
+)
+
+// NodeWatcher watches updates to core "Node" objects and takes action on their
+// events. Currently, its only responsibility is to find nodes that have a
+// "machine" annotation and link the corresponding "Machine" object to them.
+//
+// The "machine" annotation is an implementation detail of how the two objects
+// can get linked together, but it is not required behavior. However, in the
+// event that a Machine.Spec update requires replacing the Node, this can allow
+// for faster turn-around time by allowing a new Node to be created with a new
+// name while the old node is being deleted.
+//
+// Currently, these annotations are added by the node itself as part of its
+// bootup script after "kubeadm join" succeeds.
+type NodeWatcher struct {
+	nodeClient    *kubernetes.Clientset
+	machineClient clusterapiclient.MachinesInterface
+	linkedNodes   map[string]bool
+}
+
+func NewNodeWatcher(kubeconfig string) (*NodeWatcher, error) {
+	nodeClient, err := nodeClient(kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	machineClient, err := machineClient(kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &NodeWatcher{
+		nodeClient:    nodeClient,
+		machineClient: machineClient,
+		linkedNodes:   make(map[string]bool),
+	}, nil
+}
+
+func nodeClient(kubeconfig string) (*kubernetes.Clientset, error) {
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return clientset, nil
+}
+
+func machineClient(kubeconfig string) (clusterapiclient.MachinesInterface, error) {
+	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := clusterapiclient.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return client.Machines(), nil
+}
+
+func (c *NodeWatcher) Run() error {
+	glog.Infof("Running node watcher...")
+
+	return c.run(context.Background())
+}
+
+func (c *NodeWatcher) run(ctx context.Context) error {
+	source := cache.NewListWatchFromClient(c.nodeClient.CoreV1().RESTClient(), "nodes", corev1.NamespaceAll, fields.Everything())
+
+	_, informer := cache.NewInformer(
+		source,
+		&corev1.Node{},
+		0,
+		cache.ResourceEventHandlerFuncs{
+			AddFunc:    c.onAdd,
+			UpdateFunc: c.onUpdate,
+			DeleteFunc: c.onDelete,
+		},
+	)
+
+	informer.Run(ctx.Done())
+	return nil
+}
+
+func (c *NodeWatcher) onAdd(obj interface{}) {
+	node := obj.(*corev1.Node)
+	glog.Infof("node created: %s\n", node.ObjectMeta.Name)
+	c.link(node)
+}
+
+func (c *NodeWatcher) onUpdate(oldObj, newObj interface{}) {
+	newNode := newObj.(*corev1.Node)
+	glog.Infof("node updated: %s\n", newNode.ObjectMeta.Name)
+	c.link(newNode)
+}
+
+func (c *NodeWatcher) onDelete(obj interface{}) {
+	node := obj.(*corev1.Node)
+	glog.Infof("node deleted: %s\n", node.ObjectMeta.Name)
+	c.unlink(node)
+}
+
+func (c *NodeWatcher) link(node *corev1.Node) {
+	if val, _ := c.linkedNodes[node.ObjectMeta.Name]; val {
+		return
+	}
+
+	if val, ok := node.ObjectMeta.Annotations["machine"]; ok {
+		machine, err := c.machineClient.Get(val, metav1.GetOptions{})
+		if err != nil {
+			glog.Errorf("Error getting machine %v: %v\n", val, err)
+		}
+
+		machine.Status.NodeRef = objectRef(node)
+
+		if _, err := c.machineClient.Update(machine); err != nil {
+			glog.Errorf("Error updating machine to link to node: %v\n", err)
+		} else {
+			glog.Infof("Successfully linked machine to node\n")
+			c.linkedNodes[node.ObjectMeta.Name] = true
+		}
+	}
+}
+
+func (c *NodeWatcher) unlink(node *corev1.Node) {
+	if val, ok := node.ObjectMeta.Annotations["machine"]; ok {
+		machine, err := c.machineClient.Get(val, metav1.GetOptions{})
+		if err != nil {
+			glog.Errorf("Error getting machine %v: %v\n", val, err)
+		}
+
+		// This machine has no link to remove
+		if machine.Status.NodeRef == nil {
+			return
+		}
+
+		// This machine was linked to a different node, don't unlink them
+		if machine.Status.NodeRef.Name != node.ObjectMeta.Name {
+			return
+		}
+
+		machine.Status.NodeRef = nil
+
+		if _, err := c.machineClient.Update(machine); err != nil {
+			glog.Errorf("Error updating machine %s to unlink node %s: %v\n",
+				machine.ObjectMeta.Name, node.ObjectMeta.Name, err)
+		} else {
+			glog.Infof("Successfully unlinked node %s from machine %s\n",
+				node.ObjectMeta.Name, machine.ObjectMeta.Name)
+		}
+	}
+}
+
+func objectRef(node *corev1.Node) *corev1.ObjectReference {
+	return &corev1.ObjectReference{
+		Kind:      "Node",
+		Namespace: node.ObjectMeta.Namespace,
+		Name:      node.ObjectMeta.Name,
+	}
+}


### PR DESCRIPTION
When the machine-controller starts up new hosts, those hosts already self-annotate their corresponding `node` objects with the name of the `machine` that was responsible for them. Now, a new watcher in the machine-controller will look for these annotations and link the `Machine.Status.NodeRef` to the proper `node`, and unlink them on `node` deletion.