### PR TITLE
Minimal Makefile to help test builds.

### DIFF
--- a/cluster-api/Makefile
+++ b/cluster-api/Makefile
@@ -1,0 +1,10 @@
+all:
+	go build
+	cd machine-controller && go build
+	cd examples/gce-machines-controller && go build
+	cd examples/machines-client && go build
+	cd examples/machines-controller && go build
+	cd examples/machines-crd-installer && go build
+	cd examples/machineset && go build
+
+.PHONY: all


### PR DESCRIPTION
Individual components can still be built with `go build`, but now you can just run `make` to exercise the building of all of the components in the cluster-api subdir. Useful after refactoring or updating vendored dependencies.