### PR TITLE
Add another command to fix-image-permissions target.

### DIFF
--- a/cluster-api/machine-controller/Makefile
+++ b/cluster-api/machine-controller/Makefile
@@ -12,6 +12,7 @@ push: image
 	gcloud docker -- push "gcr.io/$(PROJECT)/$(NAME):$(VERSION)"
 
 fix-image-permissions:
+	gsutil acl ch -u AllUsers:READ gs://artifacts.$(PROJECT).appspot.com
 	gsutil -m acl ch -r -u AllUsers:READ gs://artifacts.$(PROJECT).appspot.com
 
 .PHONY: image push staticbuild fix-image-permissions


### PR DESCRIPTION
This only needs to run once per project, but it's biting people now that they're testing machine-controller updates using their own projects. Let's just run it every time to be sure.