### PR TITLE
Respect the spec!

### DIFF
--- a/cluster-api/cloud/actuators.go
+++ b/cluster-api/cloud/actuators.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 
 	"github.com/golang/glog"
+
 	clusterv1 "k8s.io/kube-deploy/cluster-api/api/cluster/v1alpha1"
+	"k8s.io/kube-deploy/cluster-api/client"
 	"k8s.io/kube-deploy/cluster-api/cloud/google"
 )
 
@@ -33,10 +35,10 @@ kind: config
 preferences: {}
 `
 
-func NewMachineActuator(cloud string, kubeadmToken string) (MachineActuator, error) {
+func NewMachineActuator(cloud string, kubeadmToken string, machineClient client.MachinesInterface) (MachineActuator, error) {
 	switch cloud {
 	case "google":
-		return google.NewMachineActuator(kubeadmToken)
+		return google.NewMachineActuator(kubeadmToken, machineClient)
 	case "test", "aws", "azure":
 		return &loggingMachineActuator{}, nil
 	default:

--- a/cluster-api/cloud/google/machineactuator.go
+++ b/cluster-api/cloud/google/machineactuator.go
@@ -19,21 +19,23 @@ package google
 import (
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path"
 	"strings"
-	//"os/exec"
-	"io/ioutil"
 
 	"github.com/golang/glog"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2/google"
 	compute "google.golang.org/api/compute/v1"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	clusterv1 "k8s.io/kube-deploy/cluster-api/api/cluster/v1alpha1"
+	"k8s.io/kube-deploy/cluster-api/client"
 	gceconfig "k8s.io/kube-deploy/cluster-api/cloud/google/gceproviderconfig"
 	gceconfigv1 "k8s.io/kube-deploy/cluster-api/cloud/google/gceproviderconfig/v1alpha1"
+	apierrors "k8s.io/kube-deploy/cluster-api/errors"
 	"k8s.io/kube-deploy/cluster-api/util"
 )
 
@@ -43,14 +45,15 @@ type SshCreds struct {
 }
 
 type GCEClient struct {
-	service      *compute.Service
-	scheme       *runtime.Scheme
-	codecFactory *serializer.CodecFactory
-	kubeadmToken string
-	sshCreds     SshCreds
+	service       *compute.Service
+	scheme        *runtime.Scheme
+	codecFactory  *serializer.CodecFactory
+	kubeadmToken  string
+	sshCreds      SshCreds
+	machineClient client.MachinesInterface
 }
 
-func NewMachineActuator(kubeadmToken string) (*GCEClient, error) {
+func NewMachineActuator(kubeadmToken string, machineClient client.MachinesInterface) (*GCEClient, error) {
 	// The default GCP client expects the environment variable
 	// GOOGLE_APPLICATION_CREDENTIALS to point to a file with service credentials.
 	client, err := google.DefaultClient(context.TODO(), compute.ComputeScope)
@@ -90,6 +93,7 @@ func NewMachineActuator(kubeadmToken string) (*GCEClient, error) {
 			privateKeyPath: privateKeyPath,
 			user:           user,
 		},
+		machineClient: machineClient,
 	}, nil
 }
 
@@ -123,7 +127,12 @@ func (gce *GCEClient) CreateMachineController(initialMachines []*clusterv1.Machi
 func (gce *GCEClient) Create(cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
 	config, err := gce.providerconfig(machine.Spec.ProviderConfig)
 	if err != nil {
-		return err
+		return gce.handleMachineError(machine, apierrors.InvalidMachineConfiguration(
+			"Cannot unmarshal providerConfig field: %v", err))
+	}
+
+	if verr := gce.validateMachine(machine, config); verr != nil {
+		return gce.handleMachineError(machine, verr)
 	}
 
 	var startupScript string
@@ -143,11 +152,9 @@ func (gce *GCEClient) Create(cluster *clusterv1.Cluster, machine *clusterv1.Mach
 	if util.IsMaster(machine) {
 		kubeletVersion := machine.Spec.Versions.Kubelet
 		controlPlaneVersion := machine.Spec.Versions.ControlPlane
-		if kubeletVersion == "" {
-			return fmt.Errorf("invalid master configuration: missing Machine.Spec.Versions.Kubelet")
-		}
 		if controlPlaneVersion == "" {
-			return fmt.Errorf("invalid master configuration: missing Machine.Spec.Versions.ControlPlane")
+			return gce.handleMachineError(machine, apierrors.InvalidMachineConfiguration(
+				"invalid master configuration: missing machine.spec.versions.controlPlane"))
 		}
 		startupScript = masterStartupScript(
 			gce.kubeadmToken,
@@ -214,22 +221,37 @@ func (gce *GCEClient) Create(cluster *clusterv1.Cluster, machine *clusterv1.Mach
 		},
 	}).Do()
 
-	if err != nil {
-		return err
+	if err == nil {
+		err = gce.waitForOperation(config, op)
 	}
 
-	return gce.waitForOperation(config, op)
+	if err != nil {
+		return gce.handleMachineError(machine, apierrors.CreateMachine(
+			"error creating GCE instance: %v", err))
+	}
+	return nil
 }
 
 func (gce *GCEClient) Delete(machine *clusterv1.Machine) error {
 	config, err := gce.providerconfig(machine.Spec.ProviderConfig)
 	if err != nil {
-		return err
+		return gce.handleMachineError(machine,
+			apierrors.InvalidMachineConfiguration("Cannot unmarshal providerConfig field: %v", err))
+	}
+
+	if verr := gce.validateMachine(machine, config); verr != nil {
+		return gce.handleMachineError(machine, verr)
 	}
 
 	op, err := gce.service.Instances.Delete(config.Project, config.Zone, machine.ObjectMeta.Name).Do()
-	gce.waitForOperation(config, op)
-	return err
+	if err == nil {
+		err = gce.waitForOperation(config, op)
+	}
+	if err != nil {
+		return gce.handleMachineError(machine, apierrors.DeleteMachine(
+			"error deleting GCE instance: %v", err))
+	}
+	return nil
 }
 
 func (gce *GCEClient) PostDelete(machines []*clusterv1.Machine) error {
@@ -247,7 +269,16 @@ func (gce *GCEClient) PostDelete(machines []*clusterv1.Machine) error {
 }
 
 func (gce *GCEClient) Update(cluster *clusterv1.Cluster, oldMachine *clusterv1.Machine, newMachine *clusterv1.Machine) error {
-	var err error
+	// Before updating, do some basic validation of the object first.
+	config, err := gce.providerconfig(newMachine.Spec.ProviderConfig)
+	if err != nil {
+		return gce.handleMachineError(newMachine,
+			apierrors.InvalidMachineConfiguration("Cannot unmarshal providerConfig field: %v", err))
+	}
+	if verr := gce.validateMachine(newMachine, config); verr != nil {
+		return gce.handleMachineError(newMachine, verr)
+	}
+
 	if util.IsMaster(oldMachine) {
 		glog.Infof("Doing an in-place upgrade for master.\n")
 		err = gce.updateMasterInplace(oldMachine, newMachine)
@@ -389,4 +420,34 @@ func (gce *GCEClient) updateMasterInplace(oldMachine *clusterv1.Machine, newMach
 	}
 
 	return nil
+}
+
+func (gce *GCEClient) validateMachine(machine *clusterv1.Machine, config *gceconfig.GCEProviderConfig) *apierrors.MachineError {
+	if machine.Spec.Versions.Kubelet == "" {
+		return apierrors.InvalidMachineConfiguration("spec.versions.kubelet can't be empty")
+	}
+	if machine.Spec.Versions.ContainerRuntime.Name != "docker" {
+		return apierrors.InvalidMachineConfiguration("Only docker is supported")
+	}
+	if machine.Spec.Versions.ContainerRuntime.Version != "1.12.0" {
+		return apierrors.InvalidMachineConfiguration("Only docker 1.12.0 is supported")
+	}
+	return nil
+}
+
+// If the GCEClient has a client for updating Machine objects, this will set
+// the appropriate reason/message on the Machine.Status. If not, such as during
+// cluster installation, it will operate as a no-op. It also returns the
+// original error for convenience, so callers can do "return handleMachineError(...)".
+func (gce *GCEClient) handleMachineError(machine *clusterv1.Machine, err *apierrors.MachineError) error {
+	if gce.machineClient != nil {
+		reason := err.Reason
+		message := err.Message
+		machine.Status.ErrorReason = &reason
+		machine.Status.ErrorMessage = &message
+		gce.machineClient.Update(machine)
+	}
+
+	glog.Errorf("Machine error: %v", err.Message)
+	return err
 }

--- a/cluster-api/cmd/create.go
+++ b/cluster-api/cmd/create.go
@@ -17,10 +17,11 @@ limitations under the License.
 package cmd
 
 import (
+	"os"
+
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 	"k8s.io/kube-deploy/cluster-api/deploy"
-	"os"
 )
 
 type CreateOptions struct {

--- a/cluster-api/deploy/deploy.go
+++ b/cluster-api/deploy/deploy.go
@@ -40,7 +40,7 @@ func NewDeployer(provider string, configPath string) *deployer {
 	if configPath == "" {
 		configPath = util.GetDefaultKubeConfigPath()
 	}
-	a, err := cloud.NewMachineActuator(provider, token)
+	a, err := cloud.NewMachineActuator(provider, token, nil)
 	if err != nil {
 		glog.Exit(err)
 	}

--- a/cluster-api/errors/machines.go
+++ b/cluster-api/errors/machines.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"fmt"
+
+	clusterv1 "k8s.io/kube-deploy/cluster-api/api/cluster/v1alpha1"
+)
+
+// A more descriptive kind of error that represents an error condition that
+// should be set in the Machine.Status. The "Reason" field is meant for short,
+// enum-style constants meant to be interpreted by machines. The "Message"
+// field is meant to be read by humans.
+type MachineError struct {
+	Reason  clusterv1.MachineStatusError
+	Message string
+}
+
+func (e *MachineError) Error() string {
+	return e.Message
+}
+
+// Some error builders for ease of use. They set the appropriate "Reason"
+// value, and all arguments are Printf-style varargs fed into Sprintf to
+// construct the Message.
+
+func InvalidMachineConfiguration(msg string, args ...interface{}) *MachineError {
+	return &MachineError{
+		Reason:  clusterv1.InvalidConfigurationMachineError,
+		Message: fmt.Sprintf(msg, args...),
+	}
+}
+
+func CreateMachine(msg string, args ...interface{}) *MachineError {
+	return &MachineError{
+		Reason:  clusterv1.CreateMachineError,
+		Message: fmt.Sprintf(msg, args...),
+	}
+}
+
+func DeleteMachine(msg string, args ...interface{}) *MachineError {
+	return &MachineError{
+		Reason:  clusterv1.DeleteMachineError,
+		Message: fmt.Sprintf(msg, args...),
+	}
+}

--- a/cluster-api/machine-controller/controller/client.go
+++ b/cluster-api/machine-controller/controller/client.go
@@ -24,8 +24,8 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-
 	clusterv1 "k8s.io/kube-deploy/cluster-api/api/cluster/v1alpha1"
+	"k8s.io/kube-deploy/cluster-api/client"
 )
 
 func restClient(kubeconfigpath string) (*rest.RESTClient, error) {
@@ -74,6 +74,34 @@ func kubeClientSet(kubeconfigpath string) (*kubernetes.Clientset, error) {
 	}
 
 	return client, nil
+}
+
+func nodeClient(kubeconfig string) (*kubernetes.Clientset, error) {
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return clientset, nil
+}
+
+func machineClient(kubeconfig string) (client.MachinesInterface, error) {
+	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := client.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return client.Machines(), nil
 }
 
 func host(kubeconfigpath string) (string, error) {

--- a/cluster-api/machine-controller/controller/machinecontroller.go
+++ b/cluster-api/machine-controller/controller/machinecontroller.go
@@ -58,8 +58,13 @@ func NewMachineController(config *Configuration) *MachineController {
 
 	clusterClient := client.New(restClient)
 
+	machineClient, err := machineClient(config.Kubeconfig)
+	if err != nil {
+		glog.Fatalf("error creating machine client: %v", err)
+	}
+
 	// Determine cloud type from cluster CRD when available
-	actuator, err := cloud.NewMachineActuator(config.Cloud, config.KubeadmToken)
+	actuator, err := cloud.NewMachineActuator(config.Cloud, config.KubeadmToken, machineClient)
 	if err != nil {
 		glog.Fatalf("error creating machine actuator: %v", err)
 	}

--- a/cluster-api/machine-controller/controller/nodewatcher.go
+++ b/cluster-api/machine-controller/controller/nodewatcher.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/clientcmd"
 	clusterapiclient "k8s.io/kube-deploy/cluster-api/client"
 )
 
@@ -64,34 +63,6 @@ func NewNodeWatcher(kubeconfig string) (*NodeWatcher, error) {
 		machineClient: machineClient,
 		linkedNodes:   make(map[string]bool),
 	}, nil
-}
-
-func nodeClient(kubeconfig string) (*kubernetes.Clientset, error) {
-	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
-	if err != nil {
-		return nil, err
-	}
-
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-
-	return clientset, nil
-}
-
-func machineClient(kubeconfig string) (clusterapiclient.MachinesInterface, error) {
-	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
-	if err != nil {
-		return nil, err
-	}
-
-	client, err := clusterapiclient.NewForConfig(cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	return client.Machines(), nil
 }
 
 func (c *NodeWatcher) Run() error {


### PR DESCRIPTION
Update Machine status with errors on invalid spec.
    
We don't currently support any other container runtime than Docker 1.12.0, so instead of ignoring this part of the spec, we should at least validate it and report errors on unsupported values.
