### PR TITLE
Annotate GCE machines with project/zone/name of VM.

### DIFF
--- a/cluster-api/cloud/google/pods.go
+++ b/cluster-api/cloud/google/pods.go
@@ -27,7 +27,7 @@ import (
 	"github.com/golang/glog"
 )
 
-var machineControllerImage = "gcr.io/k8s-cluster-api/machine-controller:0.8"
+var machineControllerImage = "gcr.io/k8s-cluster-api/machine-controller:0.9"
 
 func init() {
 	if img, ok := os.LookupEnv("MACHINE_CONTROLLER_IMAGE"); ok {

--- a/cluster-api/machine-controller/Makefile
+++ b/cluster-api/machine-controller/Makefile
@@ -1,6 +1,6 @@
 PROJECT=k8s-cluster-api
 NAME=machine-controller
-VERSION=0.8
+VERSION=0.9
 
 staticbuild:
 	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' .


### PR DESCRIPTION
When creating GCE VMs, annotate the corresponding machine object with the project/zone/name of the VM so that we can find it later. Otherwise, we rely on the `providerConfig` in the machine spec, which can be changed at any point.