### PR TITLE
Refer to annotations when deleting GCE machines.

### DIFF
--- a/cluster-api/cloud/google/pods.go
+++ b/cluster-api/cloud/google/pods.go
@@ -27,7 +27,7 @@ import (
 	"github.com/golang/glog"
 )
 
-var machineControllerImage = "gcr.io/k8s-cluster-api/machine-controller:0.9"
+var machineControllerImage = "gcr.io/k8s-cluster-api/machine-controller:0.10"
 
 func init() {
 	if img, ok := os.LookupEnv("MACHINE_CONTROLLER_IMAGE"); ok {

--- a/cluster-api/machine-controller/Makefile
+++ b/cluster-api/machine-controller/Makefile
@@ -1,6 +1,6 @@
 PROJECT=k8s-cluster-api
 NAME=machine-controller
-VERSION=0.9
+VERSION=0.10
 
 staticbuild:
 	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' .


### PR DESCRIPTION
Don't rely on the project/zone from the `providerConfig`, or the object name (which now allows the VM name to differ from the machine name), except as a fallback for missing annotations, like during client-side deletion.