### PR TITLE
Create new service a/c for each cluster create

### DIFF
--- a/cluster-api/cloud/actuators.go
+++ b/cluster-api/cloud/actuators.go
@@ -76,12 +76,12 @@ func (a loggingMachineActuator) GetKubeConfig(master *clusterv1.Machine) (string
 	return config, nil
 }
 
-func (a loggingMachineActuator) CreateMachineController(machines []*clusterv1.Machine) error {
+func (a loggingMachineActuator) CreateMachineController(cluster *clusterv1.Cluster, machines []*clusterv1.Machine) error {
 	glog.Infof("actuator received CreateMachineController: %q\n", machines)
 	return nil
 }
 
-func (a loggingMachineActuator) PostDelete(machines []*clusterv1.Machine) error {
+func (a loggingMachineActuator) PostDelete(cluster *clusterv1.Cluster, machines []*clusterv1.Machine) error {
 	glog.Infof("actuator received PostDelete: %q\n", machines)
 	return nil
 }

--- a/cluster-api/cloud/google/machineactuator.go
+++ b/cluster-api/cloud/google/machineactuator.go
@@ -103,19 +103,8 @@ func NewMachineActuator(kubeadmToken string, machineClient client.MachinesInterf
 	}, nil
 }
 
-func (gce *GCEClient) CreateMachineController(initialMachines []*clusterv1.Machine) error {
-	// Figure out what projects the service account needs permission to.
-	var projects []string
-	for _, machine := range initialMachines {
-		config, err := gce.providerconfig(machine.Spec.ProviderConfig)
-		if err != nil {
-			return err
-		}
-
-		projects = append(projects, config.Project)
-	}
-
-	if err := CreateMachineControllerServiceAccount(projects); err != nil {
+func (gce *GCEClient) CreateMachineController(cluster *clusterv1.Cluster, initialMachines []*clusterv1.Machine) error {
+	if err := gce.CreateMachineControllerServiceAccount(cluster, initialMachines); err != nil {
 		return err
 	}
 
@@ -292,18 +281,8 @@ func (gce *GCEClient) Delete(machine *clusterv1.Machine) error {
 	return nil
 }
 
-func (gce *GCEClient) PostDelete(machines []*clusterv1.Machine) error {
-	var projects []string
-	for _, machine := range machines {
-		config, err := gce.providerconfig(machine.Spec.ProviderConfig)
-		if err != nil {
-			return err
-		}
-
-		projects = append(projects, config.Project)
-	}
-
-	return DeleteMachineControllerServiceAccount(projects)
+func (gce *GCEClient) PostDelete(cluster *clusterv1.Cluster, machines []*clusterv1.Machine) error {
+	return gce.DeleteMachineControllerServiceAccount(cluster, machines)
 }
 
 func (gce *GCEClient) Update(cluster *clusterv1.Cluster, oldMachine *clusterv1.Machine, newMachine *clusterv1.Machine) error {

--- a/cluster-api/cloud/google/serviceaccount.go
+++ b/cluster-api/cloud/google/serviceaccount.go
@@ -18,32 +18,47 @@ package google
 
 import (
 	"fmt"
-	"github.com/golang/glog"
 	"os/exec"
+
+	"github.com/golang/glog"
+	clusterv1 "k8s.io/kube-deploy/cluster-api/api/cluster/v1alpha1"
+	"k8s.io/kube-deploy/cluster-api/util"
 )
 
 const (
-	MachineControllerServiceAccount = "k8s-machine-controller"
-	MachineControllerSecret         = "machine-controller-credential"
+	ServiceAccountPrefix    = "k8s-machine-controller-"
+	ServiceAccount          = "service-account"
+	MachineControllerSecret = "machine-controller-credential"
 )
 
 // Creates a GCP service account for the machine controller, granted the
 // permissions to manage compute instances, and stores its credentials as a
 // Kubernetes secret.
-func CreateMachineControllerServiceAccount(projects []string) error {
+func (gce *GCEClient) CreateMachineControllerServiceAccount(cluster *clusterv1.Cluster, initialMachines []*clusterv1.Machine) error {
+
+	if len(initialMachines) == 0 {
+		return fmt.Errorf("machine count is zero, cannot create service a/c")
+	}
+
 	// TODO: use real go bindings
+	// Figure out what projects the service account needs permission to.
+	projects, err := gce.getProjects(initialMachines)
+	if err != nil {
+		return err
+	}
 
 	// The service account needs to be created in a single project, so just
 	// use the first one, but grant permission to all projects in the list.
 	project := projects[0]
+	accountId := ServiceAccountPrefix + util.RandomString(5)
 
-	err := run("gcloud", "--project", project, "iam", "service-accounts", "create", "--display-name=k8s machines controller", MachineControllerServiceAccount)
+	err = run("gcloud", "--project", project, "iam", "service-accounts", "create", "--display-name=k8s machines controller", accountId)
 	if err != nil {
 		return fmt.Errorf("couldn't create service account: %v", err)
 	}
 
-	email := accountId(project)
-	localFile := MachineControllerServiceAccount + "-key.json"
+	email := fmt.Sprintf("%s@%s.iam.gserviceaccount.com", accountId, project)
+	localFile := accountId + "-key.json"
 
 	for _, project := range projects {
 		err = run("gcloud", "projects", "add-iam-policy-binding", project, "--member=serviceAccount:"+email, "--role=roles/compute.instanceAdmin.v1")
@@ -64,14 +79,36 @@ func CreateMachineControllerServiceAccount(projects []string) error {
 	if err := run("rm", localFile); err != nil {
 		glog.Error(err)
 	}
+
+	if cluster.ObjectMeta.Annotations == nil {
+		cluster.ObjectMeta.Annotations = make(map[string]string)
+	}
+	cluster.ObjectMeta.Annotations[ServiceAccount] = email
 	return nil
 }
 
-func DeleteMachineControllerServiceAccount(projects []string) error {
-	project := projects[0]
+func (gce *GCEClient) DeleteMachineControllerServiceAccount(cluster *clusterv1.Cluster, machines []*clusterv1.Machine) error {
+	if len(machines) == 0 {
+		glog.Info("machine count is zero, cannot determine project for service a/c deletion")
+		return nil
+	}
 
-	email := accountId(project)
-	err := run("gcloud", "projects", "remove-iam-policy-binding", project, "--member=serviceAccount:"+email, "--role=roles/compute.instanceAdmin.v1")
+	projects, err := gce.getProjects(machines)
+	if err != nil {
+		return err
+	}
+	project := projects[0]
+	var email string
+	if cluster.ObjectMeta.Annotations != nil {
+		email = cluster.ObjectMeta.Annotations[ServiceAccount]
+	}
+
+	if email == "" {
+		glog.Info("No service a/c found in cluster.")
+		return nil
+	}
+
+	err = run("gcloud", "projects", "remove-iam-policy-binding", project, "--member=serviceAccount:"+email, "--role=roles/compute.instanceAdmin.v1")
 
 	if err != nil {
 		return fmt.Errorf("couldn't remove permissions to service account: %v", err)
@@ -84,8 +121,18 @@ func DeleteMachineControllerServiceAccount(projects []string) error {
 	return nil
 }
 
-func accountId(project string) string {
-	return fmt.Sprintf("%s@%s.iam.gserviceaccount.com", MachineControllerServiceAccount, project)
+func (gce *GCEClient) getProjects(machines []*clusterv1.Machine) ([]string, error) {
+	// Figure out what projects the service account needs permission to.
+	var projects []string
+	for _, machine := range machines {
+		config, err := gce.providerconfig(machine.Spec.ProviderConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		projects = append(projects, config.Project)
+	}
+	return projects, nil
 }
 
 func run(cmd string, args ...string) error {

--- a/cluster-api/cloud/machineactuator.go
+++ b/cluster-api/cloud/machineactuator.go
@@ -33,6 +33,6 @@ type MachineActuator interface {
 	// machines don't have to be reconciled as part of this function, but
 	// are provided in case the function wants to refer to them (and their
 	// ProviderConfigs) to know how to configure the machine controller.
-	CreateMachineController(initialMachines []*clusterv1.Machine) error
-	PostDelete(machines []*clusterv1.Machine) error
+	CreateMachineController(cluster *clusterv1.Cluster, initialMachines []*clusterv1.Machine) error
+	PostDelete(cluster *clusterv1.Cluster, machines []*clusterv1.Machine) error
 }

--- a/cluster-api/deploy/deploy_helper.go
+++ b/cluster-api/deploy/deploy_helper.go
@@ -128,6 +128,17 @@ func (d *deployer) listMachines() ([]*clusterv1.Machine, error) {
 	return util.MachineP(machines.Items), nil
 }
 
+func (d *deployer) getCluster() (*clusterv1.Cluster, error) {
+	clusters, err := d.client.Clusters().List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	if len(clusters.Items) != 1 {
+		return nil, fmt.Errorf("cluster object count != 1")
+	}
+	return &clusters.Items[0], nil
+}
+
 func (d *deployer) getMasterIP(master *clusterv1.Machine) (string, error) {
 	for i := 0; i < MasterIPAttempts; i++ {
 		ip, err := d.actuator.GetIP(master)

--- a/cluster-api/util/util.go
+++ b/cluster-api/util/util.go
@@ -43,10 +43,10 @@ var (
 )
 
 func RandomToken() string {
-	return fmt.Sprintf("%s.%s", randomString(6), randomString(16))
+	return fmt.Sprintf("%s.%s", RandomString(6), RandomString(16))
 }
 
-func randomString(n int) string {
+func RandomString(n int) string {
 	result := make([]byte, n)
 	for i := range result {
 		result[i] = CharSet[r.Intn(len(CharSet))]


### PR DESCRIPTION
Currently cluster-api doesn't create different service a/c for different clusters. This results into weird error cases when user creates multiple clusters.

This PR should streamline service a/c maintenance.