### PR TITLE
imagebuilder: Use a different instance type in us-east-2

### DIFF
--- a/imagebuilder/pkg/imagebuilder/config.go
+++ b/imagebuilder/pkg/imagebuilder/config.go
@@ -98,6 +98,12 @@ func (c *AWSConfig) InitDefaults(region string) {
 	default:
 		glog.Warningf("Building in unknown region %q - will require specifying an image, may not work correctly")
 	}
+
+	// Not all regions support m3.medium
+	switch c.Region {
+	case "us-east-2":
+		c.InstanceType = "m4.large"
+	}
 }
 
 type GCEConfig struct {


### PR DESCRIPTION
The m3 family is not available in us-east-2