### PR TITLE
Fix missing returns in node watcher

### DIFF
--- a/cluster-api/cloud/google/pods.go
+++ b/cluster-api/cloud/google/pods.go
@@ -27,7 +27,7 @@ import (
 	"github.com/golang/glog"
 )
 
-var machineControllerImage = "gcr.io/k8s-cluster-api/machine-controller:0.13"
+var machineControllerImage = "gcr.io/k8s-cluster-api/machine-controller:0.14"
 
 func init() {
 	if img, ok := os.LookupEnv("MACHINE_CONTROLLER_IMAGE"); ok {

--- a/cluster-api/machine-controller/Makefile
+++ b/cluster-api/machine-controller/Makefile
@@ -1,6 +1,6 @@
 PROJECT=k8s-cluster-api
 NAME=machine-controller
-VERSION=0.13
+VERSION=0.14
 
 staticbuild:
 	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' .

--- a/cluster-api/machine-controller/controller/nodewatcher.go
+++ b/cluster-api/machine-controller/controller/nodewatcher.go
@@ -116,6 +116,7 @@ func (c *NodeWatcher) link(node *corev1.Node) {
 		machine, err := c.machineClient.Get(val, metav1.GetOptions{})
 		if err != nil {
 			glog.Errorf("Error getting machine %v: %v\n", val, err)
+			return
 		}
 
 		machine.Status.NodeRef = objectRef(node)
@@ -135,6 +136,7 @@ func (c *NodeWatcher) unlink(node *corev1.Node) {
 		machine, err := c.machineClient.Get(val, metav1.GetOptions{})
 		if err != nil {
 			glog.Errorf("Error getting machine %v: %v\n", val, err)
+			return
 		}
 
 		// This machine has no link to remove


### PR DESCRIPTION
Lack of said returns caused exotic loops where machines were not properly deleted if the node appeared while the machine was in the middle of being deleted.