### PR TITLE
Use a prebaked OS image for GCE instances.

### DIFF
--- a/cluster-api/cloud/google/pods.go
+++ b/cluster-api/cloud/google/pods.go
@@ -27,7 +27,7 @@ import (
 	"github.com/golang/glog"
 )
 
-var machineControllerImage = "gcr.io/k8s-cluster-api/machine-controller:0.16"
+var machineControllerImage = "gcr.io/k8s-cluster-api/machine-controller:0.17"
 
 func init() {
 	if img, ok := os.LookupEnv("MACHINE_CONTROLLER_IMAGE"); ok {

--- a/cluster-api/machine-controller/Makefile
+++ b/cluster-api/machine-controller/Makefile
@@ -1,6 +1,6 @@
 PROJECT=k8s-cluster-api
 NAME=machine-controller
-VERSION=0.16
+VERSION=0.17
 
 staticbuild:
 	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' .

--- a/cluster-api/machine-controller/controller/asyncrunner.go
+++ b/cluster-api/machine-controller/controller/asyncrunner.go
@@ -8,25 +8,25 @@ const workQueueMax int = 100
 // against a single id serially and do work against
 // different ids in parallel
 type asyncRunner struct {
-	lock *sync.Mutex
+	lock       *sync.Mutex
 	workQueues map[string]workQueue
 }
 
 type workQueue struct {
-	lock *sync.Mutex
+	lock  *sync.Mutex
 	queue chan func()
 }
 
 func newAsyncRunner() *asyncRunner {
 	return &asyncRunner{
-		lock: &sync.Mutex{},
+		lock:       &sync.Mutex{},
 		workQueues: map[string]workQueue{},
 	}
 }
 
 func newWorkQueue() workQueue {
 	return workQueue{
-		lock: &sync.Mutex{},
+		lock:  &sync.Mutex{},
 		queue: make(chan func(), workQueueMax),
 	}
 }
@@ -52,7 +52,7 @@ func (r *asyncRunner) run(id string, f func()) {
 	wq.lock.Lock()
 	defer wq.lock.Unlock()
 
-	w := <- wq.queue
+	w := <-wq.queue
 	w()
 }
 

--- a/cluster-api/machine-controller/controller/machinecontroller.go
+++ b/cluster-api/machine-controller/controller/machinecontroller.go
@@ -84,7 +84,7 @@ func NewMachineController(config *Configuration) *MachineController {
 		actuator:      actuator,
 		nodeWatcher:   nodeWatcher,
 		machineClient: machineClient,
-		runner: newAsyncRunner(),
+		runner:        newAsyncRunner(),
 	}
 }
 
@@ -126,7 +126,7 @@ func (c *MachineController) onAdd(obj interface{}) {
 		return
 	}
 
-	c.runner.runAsync(machine.ObjectMeta.Name, func(){
+	c.runner.runAsync(machine.ObjectMeta.Name, func() {
 		err := c.create(machine)
 		if err != nil {
 			glog.Errorf("create machine %s failed: %v", machine.ObjectMeta.Name, err)
@@ -147,8 +147,8 @@ func (c *MachineController) onUpdate(oldObj, newObj interface{}) {
 		return
 	}
 
-	c.runner.runAsync(newMachine.ObjectMeta.Name, func(){
-		err := 	c.update(oldMachine, newMachine)
+	c.runner.runAsync(newMachine.ObjectMeta.Name, func() {
+		err := c.update(oldMachine, newMachine)
 		if err != nil {
 			glog.Errorf("update machine %s failed: %v", newMachine.ObjectMeta.Name, err)
 		} else {
@@ -165,7 +165,7 @@ func (c *MachineController) onDelete(obj interface{}) {
 		return
 	}
 
-	c.runner.runAsync(machine.ObjectMeta.Name, func(){
+	c.runner.runAsync(machine.ObjectMeta.Name, func() {
 		err := c.delete(machine)
 		if err != nil {
 			glog.Errorf("delete machine %s failed: %v", machine.ObjectMeta.Name, err)
@@ -206,7 +206,7 @@ func (c *MachineController) create(machine *clusterv1.Machine) error {
 	if err != nil {
 		glog.Errorf("Skipping machine create due to error getting machine %v: %v\n", machine.ObjectMeta.Name, err)
 		return err
-	}	
+	}
 
 	return c.actuator.Create(cluster, machine)
 }


### PR DESCRIPTION
This will speed up the demo by having OS packages and Docker images pre-pulled. In the future, we may want specialized prebaked images based off of different base images, Machine role, Kubernetes version, etc., but for now, a single monolithic image gives us a good speed-up.