### PR TITLE
Bootstrap new API resource cluster.k8s.io/v1alpha1/Machine and cluster.k8s.io/v1alpha1/Cluster

### DIFF
--- a/ext-apiserver/cmd/apiserver/main.go
+++ b/ext-apiserver/cmd/apiserver/main.go
@@ -32,5 +32,5 @@ import (
 
 func main() {
 	version := "v0"
-	server.StartApiServer("/registry/cluster.k8s.io", apis.GetAllApiBuilders(), openapi.GetOpenAPIDefinitions, "Api", version)
+	server.StartApiServer("/registry/k8s.io", apis.GetAllApiBuilders(), openapi.GetOpenAPIDefinitions, "Api", version)
 }

--- a/ext-apiserver/docs/examples/cluster/cluster.yaml
+++ b/ext-apiserver/docs/examples/cluster/cluster.yaml
@@ -1,6 +1,6 @@
 note: Cluster Example
 sample: |
-  apiVersion: cluster.cluster.k8s.io/v1alpha1
+  apiVersion: cluster.k8s.io/v1alpha1
   kind: Cluster
   metadata:
     name: cluster-example

--- a/ext-apiserver/docs/examples/cluster/cluster.yaml
+++ b/ext-apiserver/docs/examples/cluster/cluster.yaml
@@ -1,0 +1,7 @@
+note: Cluster Example
+sample: |
+  apiVersion: cluster.cluster.k8s.io/v1alpha1
+  kind: Cluster
+  metadata:
+    name: cluster-example
+  spec:

--- a/ext-apiserver/docs/examples/machine/machine.yaml
+++ b/ext-apiserver/docs/examples/machine/machine.yaml
@@ -1,0 +1,7 @@
+note: Machine Example
+sample: |
+  apiVersion: cluster.cluster.k8s.io/v1alpha1
+  kind: Machine
+  metadata:
+    name: machine-example
+  spec:

--- a/ext-apiserver/docs/examples/machine/machine.yaml
+++ b/ext-apiserver/docs/examples/machine/machine.yaml
@@ -1,6 +1,6 @@
 note: Machine Example
 sample: |
-  apiVersion: cluster.cluster.k8s.io/v1alpha1
+  apiVersion: cluster.k8s.io/v1alpha1
   kind: Machine
   metadata:
     name: machine-example

--- a/ext-apiserver/pkg/apis/cluster/doc.go
+++ b/ext-apiserver/pkg/apis/cluster/doc.go
@@ -1,0 +1,25 @@
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+
+// +k8s:deepcopy-gen=package,register
+// +groupName=cluster.cluster.k8s.io
+
+// Package api is the internal version of the API.
+package cluster
+

--- a/ext-apiserver/pkg/apis/cluster/doc.go
+++ b/ext-apiserver/pkg/apis/cluster/doc.go
@@ -18,7 +18,7 @@ limitations under the License.
 
 
 // +k8s:deepcopy-gen=package,register
-// +groupName=cluster.cluster.k8s.io
+// +groupName=cluster.k8s.io
 
 // Package api is the internal version of the API.
 package cluster

--- a/ext-apiserver/pkg/apis/cluster/install/doc.go
+++ b/ext-apiserver/pkg/apis/cluster/install/doc.go
@@ -1,0 +1,20 @@
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+package install
+

--- a/ext-apiserver/pkg/apis/cluster/v1alpha1/cluster_types.go
+++ b/ext-apiserver/pkg/apis/cluster/v1alpha1/cluster_types.go
@@ -1,0 +1,69 @@
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+package v1alpha1
+
+import (
+	"log"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/endpoints/request"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"k8s.io/kube-deploy/ext-apiserver/pkg/apis/cluster"
+)
+
+// +genclient
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// Cluster
+// +k8s:openapi-gen=true
+// +resource:path=clusters,strategy=ClusterStrategy
+type Cluster struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   ClusterSpec   `json:"spec,omitempty"`
+	Status ClusterStatus `json:"status,omitempty"`
+}
+
+// ClusterSpec defines the desired state of Cluster
+type ClusterSpec struct {
+}
+
+// ClusterStatus defines the observed state of Cluster
+type ClusterStatus struct {
+}
+
+// Validate checks that an instance of Cluster is well formed
+func (ClusterStrategy) Validate(ctx request.Context, obj runtime.Object) field.ErrorList {
+	o := obj.(*cluster.Cluster)
+	log.Printf("Validating fields for Cluster %s\n", o.Name)
+	errors := field.ErrorList{}
+	// perform validation here and add to errors using field.Invalid
+	return errors
+}
+
+// DefaultingFunction sets default Cluster field values
+func (ClusterSchemeFns) DefaultingFunction(o interface{}) {
+	obj := o.(*Cluster)
+	// set default field values here
+	log.Printf("Defaulting fields for Cluster %s\n", obj.Name)
+}

--- a/ext-apiserver/pkg/apis/cluster/v1alpha1/cluster_types_test.go
+++ b/ext-apiserver/pkg/apis/cluster/v1alpha1/cluster_types_test.go
@@ -1,0 +1,79 @@
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+package v1alpha1_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "k8s.io/kube-deploy/ext-apiserver/pkg/apis/cluster/v1alpha1"
+	. "k8s.io/kube-deploy/ext-apiserver/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1"
+)
+
+var _ = Describe("Cluster", func() {
+	var instance Cluster
+	var expected Cluster
+	var client ClusterInterface
+
+	BeforeEach(func() {
+		instance = Cluster{}
+		instance.Name = "instance-1"
+
+		expected = instance
+	})
+
+	AfterEach(func() {
+		client.Delete(instance.Name, &metav1.DeleteOptions{})
+	})
+
+	Describe("when sending a storage request", func() {
+		Context("for a valid config", func() {
+			It("should provide CRUD access to the object", func() {
+				client = cs.ClusterV1alpha1().Clusters("cluster-test-valid")
+
+				By("returning success from the create request")
+				actual, err := client.Create(&instance)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				By("defaulting the expected fields")
+				Expect(actual.Spec).To(Equal(expected.Spec))
+
+				By("returning the item for list requests")
+				result, err := client.List(metav1.ListOptions{})
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(result.Items).To(HaveLen(1))
+				Expect(result.Items[0].Spec).To(Equal(expected.Spec))
+
+				By("returning the item for get requests")
+				actual, err = client.Get(instance.Name, metav1.GetOptions{})
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(actual.Spec).To(Equal(expected.Spec))
+
+				By("deleting the item for delete requests")
+				err = client.Delete(instance.Name, &metav1.DeleteOptions{})
+				Expect(err).ShouldNot(HaveOccurred())
+				result, err = client.List(metav1.ListOptions{})
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(result.Items).To(HaveLen(0))
+			})
+		})
+	})
+})

--- a/ext-apiserver/pkg/apis/cluster/v1alpha1/doc.go
+++ b/ext-apiserver/pkg/apis/cluster/v1alpha1/doc.go
@@ -1,0 +1,29 @@
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+// Api versions allow the api contract for a resource to be changed while keeping
+// backward compatibility by support multiple concurrent versions
+// of the same resource
+
+// +k8s:openapi-gen=true
+// +k8s:deepcopy-gen=package,register
+// +k8s:conversion-gen=k8s.io/kube-deploy/ext-apiserver/pkg/apis/cluster
+// +k8s:defaulter-gen=TypeMeta
+// +groupName=cluster.cluster.k8s.io
+package v1alpha1 // import "k8s.io/kube-deploy/ext-apiserver/pkg/apis/cluster/v1alpha1"
+

--- a/ext-apiserver/pkg/apis/cluster/v1alpha1/doc.go
+++ b/ext-apiserver/pkg/apis/cluster/v1alpha1/doc.go
@@ -24,6 +24,6 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=k8s.io/kube-deploy/ext-apiserver/pkg/apis/cluster
 // +k8s:defaulter-gen=TypeMeta
-// +groupName=cluster.cluster.k8s.io
+// +groupName=cluster.k8s.io
 package v1alpha1 // import "k8s.io/kube-deploy/ext-apiserver/pkg/apis/cluster/v1alpha1"
 

--- a/ext-apiserver/pkg/apis/cluster/v1alpha1/machine_types.go
+++ b/ext-apiserver/pkg/apis/cluster/v1alpha1/machine_types.go
@@ -1,0 +1,69 @@
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+package v1alpha1
+
+import (
+	"log"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/endpoints/request"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"k8s.io/kube-deploy/ext-apiserver/pkg/apis/cluster"
+)
+
+// +genclient
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// Machine
+// +k8s:openapi-gen=true
+// +resource:path=machines,strategy=MachineStrategy
+type Machine struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   MachineSpec   `json:"spec,omitempty"`
+	Status MachineStatus `json:"status,omitempty"`
+}
+
+// MachineSpec defines the desired state of Machine
+type MachineSpec struct {
+}
+
+// MachineStatus defines the observed state of Machine
+type MachineStatus struct {
+}
+
+// Validate checks that an instance of Machine is well formed
+func (MachineStrategy) Validate(ctx request.Context, obj runtime.Object) field.ErrorList {
+	o := obj.(*cluster.Machine)
+	log.Printf("Validating fields for Machine %s\n", o.Name)
+	errors := field.ErrorList{}
+	// perform validation here and add to errors using field.Invalid
+	return errors
+}
+
+// DefaultingFunction sets default Machine field values
+func (MachineSchemeFns) DefaultingFunction(o interface{}) {
+	obj := o.(*Machine)
+	// set default field values here
+	log.Printf("Defaulting fields for Machine %s\n", obj.Name)
+}

--- a/ext-apiserver/pkg/apis/cluster/v1alpha1/machine_types_test.go
+++ b/ext-apiserver/pkg/apis/cluster/v1alpha1/machine_types_test.go
@@ -1,0 +1,79 @@
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+package v1alpha1_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "k8s.io/kube-deploy/ext-apiserver/pkg/apis/cluster/v1alpha1"
+	. "k8s.io/kube-deploy/ext-apiserver/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1"
+)
+
+var _ = Describe("Machine", func() {
+	var instance Machine
+	var expected Machine
+	var client MachineInterface
+
+	BeforeEach(func() {
+		instance = Machine{}
+		instance.Name = "instance-1"
+
+		expected = instance
+	})
+
+	AfterEach(func() {
+		client.Delete(instance.Name, &metav1.DeleteOptions{})
+	})
+
+	Describe("when sending a storage request", func() {
+		Context("for a valid config", func() {
+			It("should provide CRUD access to the object", func() {
+				client = cs.ClusterV1alpha1().Machines("machine-test-valid")
+
+				By("returning success from the create request")
+				actual, err := client.Create(&instance)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				By("defaulting the expected fields")
+				Expect(actual.Spec).To(Equal(expected.Spec))
+
+				By("returning the item for list requests")
+				result, err := client.List(metav1.ListOptions{})
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(result.Items).To(HaveLen(1))
+				Expect(result.Items[0].Spec).To(Equal(expected.Spec))
+
+				By("returning the item for get requests")
+				actual, err = client.Get(instance.Name, metav1.GetOptions{})
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(actual.Spec).To(Equal(expected.Spec))
+
+				By("deleting the item for delete requests")
+				err = client.Delete(instance.Name, &metav1.DeleteOptions{})
+				Expect(err).ShouldNot(HaveOccurred())
+				result, err = client.List(metav1.ListOptions{})
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(result.Items).To(HaveLen(0))
+			})
+		})
+	})
+})

--- a/ext-apiserver/pkg/apis/cluster/v1alpha1/v1alpha1_suite_test.go
+++ b/ext-apiserver/pkg/apis/cluster/v1alpha1/v1alpha1_suite_test.go
@@ -1,0 +1,51 @@
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+package v1alpha1_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/kubernetes-incubator/apiserver-builder/pkg/test"
+	"k8s.io/client-go/rest"
+
+	"k8s.io/kube-deploy/ext-apiserver/pkg/apis"
+	"k8s.io/kube-deploy/ext-apiserver/pkg/client/clientset_generated/clientset"
+	"k8s.io/kube-deploy/ext-apiserver/pkg/openapi"
+)
+
+var testenv *test.TestEnvironment
+var config *rest.Config
+var cs *clientset.Clientset
+
+func TestV1alpha1(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecsWithDefaultAndCustomReporters(t, "v1 Suite", []Reporter{test.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func() {
+	testenv = test.NewTestEnvironment()
+	config = testenv.Start(apis.GetAllApiBuilders(), openapi.GetOpenAPIDefinitions)
+	cs = clientset.NewForConfigOrDie(config)
+})
+
+var _ = AfterSuite(func() {
+	testenv.Stop()
+})

--- a/ext-apiserver/pkg/apis/doc.go
+++ b/ext-apiserver/pkg/apis/doc.go
@@ -18,7 +18,7 @@ limitations under the License.
 
 
 //
-// +domain=cluster.k8s.io
+// +domain=k8s.io
 
 package apis
 

--- a/ext-apiserver/pkg/controller/cluster/cluster_suite_test.go
+++ b/ext-apiserver/pkg/controller/cluster/cluster_suite_test.go
@@ -1,0 +1,62 @@
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+package cluster_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/rest"
+	"github.com/kubernetes-incubator/apiserver-builder/pkg/test"
+
+	"k8s.io/kube-deploy/ext-apiserver/pkg/apis"
+	"k8s.io/kube-deploy/ext-apiserver/pkg/client/clientset_generated/clientset"
+	"k8s.io/kube-deploy/ext-apiserver/pkg/openapi"
+	"k8s.io/kube-deploy/ext-apiserver/pkg/controller/sharedinformers"
+	"k8s.io/kube-deploy/ext-apiserver/pkg/controller/cluster"
+)
+
+var testenv *test.TestEnvironment
+var config *rest.Config
+var cs *clientset.Clientset
+var shutdown chan struct{}
+var controller *cluster.ClusterController
+var si *sharedinformers.SharedInformers
+
+func TestCluster(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecsWithDefaultAndCustomReporters(t, "Cluster Suite", []Reporter{test.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func() {
+	testenv = test.NewTestEnvironment()
+	config = testenv.Start(apis.GetAllApiBuilders(), openapi.GetOpenAPIDefinitions)
+	cs = clientset.NewForConfigOrDie(config)
+
+	shutdown = make(chan struct{})
+	si = sharedinformers.NewSharedInformers(config, shutdown)
+	controller = cluster.NewClusterController(config, si)
+	controller.Run(shutdown)
+})
+
+var _ = AfterSuite(func() {
+	close(shutdown)
+	testenv.Stop()
+})

--- a/ext-apiserver/pkg/controller/cluster/controller.go
+++ b/ext-apiserver/pkg/controller/cluster/controller.go
@@ -1,0 +1,55 @@
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+package cluster
+
+import (
+	"log"
+
+	"github.com/kubernetes-incubator/apiserver-builder/pkg/builders"
+
+	"k8s.io/kube-deploy/ext-apiserver/pkg/apis/cluster/v1alpha1"
+	"k8s.io/kube-deploy/ext-apiserver/pkg/controller/sharedinformers"
+	listers "k8s.io/kube-deploy/ext-apiserver/pkg/client/listers_generated/cluster/v1alpha1"
+)
+
+// +controller:group=cluster,version=v1alpha1,kind=Cluster,resource=clusters
+type ClusterControllerImpl struct {
+	builders.DefaultControllerFns
+
+	// lister indexes properties about Cluster
+	lister listers.ClusterLister
+}
+
+// Init initializes the controller and is called by the generated code
+// Register watches for additional resource types here.
+func (c *ClusterControllerImpl) Init(arguments sharedinformers.ControllerInitArguments) {
+	// Use the lister for indexing clusters labels
+	c.lister = arguments.GetSharedInformers().Factory.Cluster().V1alpha1().Clusters().Lister()
+}
+
+// Reconcile handles enqueued messages
+func (c *ClusterControllerImpl) Reconcile(u *v1alpha1.Cluster) error {
+	// Implement controller logic here
+	log.Printf("Running reconcile Cluster for %s\n", u.Name)
+	return nil
+}
+
+func (c *ClusterControllerImpl) Get(namespace, name string) (*v1alpha1.Cluster, error) {
+	return c.lister.Clusters(namespace).Get(name)
+}

--- a/ext-apiserver/pkg/controller/cluster/controller_test.go
+++ b/ext-apiserver/pkg/controller/cluster/controller_test.go
@@ -1,0 +1,91 @@
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+package cluster_test
+
+import (
+	"time"
+
+	. "k8s.io/kube-deploy/ext-apiserver/pkg/apis/cluster/v1alpha1"
+	. "k8s.io/kube-deploy/ext-apiserver/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Cluster controller", func() {
+	var instance Cluster
+	var expectedKey string
+	var client ClusterInterface
+	var before chan struct{}
+	var after chan struct{}
+
+	BeforeEach(func() {
+		instance = Cluster{}
+		instance.Name = "instance-1"
+		expectedKey = "cluster-controller-test-handler/instance-1"
+	})
+
+	AfterEach(func() {
+		client.Delete(instance.Name, &metav1.DeleteOptions{})
+	})
+
+	Describe("when creating a new object", func() {
+		It("invoke the reconcile method", func() {
+			client = cs.ClusterV1alpha1().Clusters("cluster-controller-test-handler")
+			before = make(chan struct{})
+			after = make(chan struct{})
+
+			actualKey := ""
+			var actualErr error = nil
+
+			// Setup test callbacks to be called when the message is reconciled
+			controller.BeforeReconcile = func(key string) {
+				defer close(before)
+				actualKey = key
+			}
+			controller.AfterReconcile = func(key string, err error) {
+				defer close(after)
+				actualKey = key
+				actualErr = err
+			}
+
+			// Create an instance
+			_, err := client.Create(&instance)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Verify reconcile function is called against the correct key
+			select {
+			case <-before:
+				Expect(actualKey).To(Equal(expectedKey))
+				Expect(actualErr).ShouldNot(HaveOccurred())
+			case <-time.After(time.Second * 2):
+				Fail("reconcile never called")
+			}
+
+			select {
+			case <-after:
+				Expect(actualKey).To(Equal(expectedKey))
+				Expect(actualErr).ShouldNot(HaveOccurred())
+			case <-time.After(time.Second * 2):
+				Fail("reconcile never finished")
+			}
+		})
+	})
+})

--- a/ext-apiserver/pkg/controller/machine/controller.go
+++ b/ext-apiserver/pkg/controller/machine/controller.go
@@ -1,0 +1,55 @@
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+package machine
+
+import (
+	"log"
+
+	"github.com/kubernetes-incubator/apiserver-builder/pkg/builders"
+
+	"k8s.io/kube-deploy/ext-apiserver/pkg/apis/cluster/v1alpha1"
+	"k8s.io/kube-deploy/ext-apiserver/pkg/controller/sharedinformers"
+	listers "k8s.io/kube-deploy/ext-apiserver/pkg/client/listers_generated/cluster/v1alpha1"
+)
+
+// +controller:group=cluster,version=v1alpha1,kind=Machine,resource=machines
+type MachineControllerImpl struct {
+	builders.DefaultControllerFns
+
+	// lister indexes properties about Machine
+	lister listers.MachineLister
+}
+
+// Init initializes the controller and is called by the generated code
+// Register watches for additional resource types here.
+func (c *MachineControllerImpl) Init(arguments sharedinformers.ControllerInitArguments) {
+	// Use the lister for indexing machines labels
+	c.lister = arguments.GetSharedInformers().Factory.Cluster().V1alpha1().Machines().Lister()
+}
+
+// Reconcile handles enqueued messages
+func (c *MachineControllerImpl) Reconcile(u *v1alpha1.Machine) error {
+	// Implement controller logic here
+	log.Printf("Running reconcile Machine for %s\n", u.Name)
+	return nil
+}
+
+func (c *MachineControllerImpl) Get(namespace, name string) (*v1alpha1.Machine, error) {
+	return c.lister.Machines(namespace).Get(name)
+}

--- a/ext-apiserver/pkg/controller/machine/controller_test.go
+++ b/ext-apiserver/pkg/controller/machine/controller_test.go
@@ -1,0 +1,91 @@
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+package machine_test
+
+import (
+	"time"
+
+	. "k8s.io/kube-deploy/ext-apiserver/pkg/apis/cluster/v1alpha1"
+	. "k8s.io/kube-deploy/ext-apiserver/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Machine controller", func() {
+	var instance Machine
+	var expectedKey string
+	var client MachineInterface
+	var before chan struct{}
+	var after chan struct{}
+
+	BeforeEach(func() {
+		instance = Machine{}
+		instance.Name = "instance-1"
+		expectedKey = "machine-controller-test-handler/instance-1"
+	})
+
+	AfterEach(func() {
+		client.Delete(instance.Name, &metav1.DeleteOptions{})
+	})
+
+	Describe("when creating a new object", func() {
+		It("invoke the reconcile method", func() {
+			client = cs.ClusterV1alpha1().Machines("machine-controller-test-handler")
+			before = make(chan struct{})
+			after = make(chan struct{})
+
+			actualKey := ""
+			var actualErr error = nil
+
+			// Setup test callbacks to be called when the message is reconciled
+			controller.BeforeReconcile = func(key string) {
+				defer close(before)
+				actualKey = key
+			}
+			controller.AfterReconcile = func(key string, err error) {
+				defer close(after)
+				actualKey = key
+				actualErr = err
+			}
+
+			// Create an instance
+			_, err := client.Create(&instance)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Verify reconcile function is called against the correct key
+			select {
+			case <-before:
+				Expect(actualKey).To(Equal(expectedKey))
+				Expect(actualErr).ShouldNot(HaveOccurred())
+			case <-time.After(time.Second * 2):
+				Fail("reconcile never called")
+			}
+
+			select {
+			case <-after:
+				Expect(actualKey).To(Equal(expectedKey))
+				Expect(actualErr).ShouldNot(HaveOccurred())
+			case <-time.After(time.Second * 2):
+				Fail("reconcile never finished")
+			}
+		})
+	})
+})

--- a/ext-apiserver/pkg/controller/machine/machine_suite_test.go
+++ b/ext-apiserver/pkg/controller/machine/machine_suite_test.go
@@ -1,0 +1,62 @@
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+package machine_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/rest"
+	"github.com/kubernetes-incubator/apiserver-builder/pkg/test"
+
+	"k8s.io/kube-deploy/ext-apiserver/pkg/apis"
+	"k8s.io/kube-deploy/ext-apiserver/pkg/client/clientset_generated/clientset"
+	"k8s.io/kube-deploy/ext-apiserver/pkg/openapi"
+	"k8s.io/kube-deploy/ext-apiserver/pkg/controller/sharedinformers"
+	"k8s.io/kube-deploy/ext-apiserver/pkg/controller/machine"
+)
+
+var testenv *test.TestEnvironment
+var config *rest.Config
+var cs *clientset.Clientset
+var shutdown chan struct{}
+var controller *machine.MachineController
+var si *sharedinformers.SharedInformers
+
+func TestMachine(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecsWithDefaultAndCustomReporters(t, "Machine Suite", []Reporter{test.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func() {
+	testenv = test.NewTestEnvironment()
+	config = testenv.Start(apis.GetAllApiBuilders(), openapi.GetOpenAPIDefinitions)
+	cs = clientset.NewForConfigOrDie(config)
+
+	shutdown = make(chan struct{})
+	si = sharedinformers.NewSharedInformers(config, shutdown)
+	controller = machine.NewMachineController(config, si)
+	controller.Run(shutdown)
+})
+
+var _ = AfterSuite(func() {
+	close(shutdown)
+	testenv.Stop()
+})

--- a/ext-apiserver/pkg/controller/sharedinformers/informers.go
+++ b/ext-apiserver/pkg/controller/sharedinformers/informers.go
@@ -1,0 +1,35 @@
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+package sharedinformers
+
+// SetupKubernetesTypes registers the config for watching Kubernetes types
+func (si *SharedInformers) SetupKubernetesTypes() bool {
+    // Set this to true to initial the ClientSet and InformerFactory for
+    // Kubernetes APIs (e.g. Deployment)
+	return false
+}
+
+// StartAdditionalInformers starts watching Deployments
+func (si *SharedInformers) StartAdditionalInformers(shutdown <-chan struct{}) {
+    // Start specific Kubernetes API informers here.  Note, it is only necessary
+    // to start 1 informer for each Kind. (e.g. only 1 Deployment informer)
+
+    // Uncomment this to start listening for Deployment Create / Update / Deletes
+    // go si.KubernetesFactory.Apps().V1beta1().Deployments().Informer().Run(shutdown)
+}

--- a/ext-apiserver/sample/cluster.yaml
+++ b/ext-apiserver/sample/cluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.cluster.k8s.io/v1alpha1
+apiVersion: cluster.k8s.io/v1alpha1
 kind: Cluster
 metadata:
   name: cluster-example

--- a/ext-apiserver/sample/cluster.yaml
+++ b/ext-apiserver/sample/cluster.yaml
@@ -1,0 +1,5 @@
+apiVersion: cluster.cluster.k8s.io/v1alpha1
+kind: Cluster
+metadata:
+  name: cluster-example
+spec:

--- a/ext-apiserver/sample/machine.yaml
+++ b/ext-apiserver/sample/machine.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.cluster.k8s.io/v1alpha1
+apiVersion: cluster.k8s.io/v1alpha1
 kind: Machine
 metadata:
   name: machine-example

--- a/ext-apiserver/sample/machine.yaml
+++ b/ext-apiserver/sample/machine.yaml
@@ -1,0 +1,5 @@
+apiVersion: cluster.cluster.k8s.io/v1alpha1
+kind: Machine
+metadata:
+  name: machine-example
+spec:


### PR DESCRIPTION
Generate skeleton codes (100% generated by tool) for new resources. The following up PR will migrate all the type definition from CRD with code generation. It also fixed the domain name from cluster.k8s.io to k8s.io


apiserver-boot create group version resource --group simple --version v1alpha1  --kind Machine
apiserver-boot create group version resource --group simple --version v1alpha1  --kind Cluster

- create the resource type definition
- create tests for the resource
- create controller that listens for the resource
- create tests for the controller
- create an example for the reference documentation
- create a sample to use for testing
