### PR TITLE
Remove hard-coded project IDs (using gcloud for that info instead) + update CONTRIBUTING

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -11,10 +11,10 @@ aliases:
     - krousey
     - luxas
     - roberthbailey
-    - rsdcastro
   kube-deploy-maintainers:
     - jessicaochen
     - kris-nova
     - krousey
     - medinatiger
     - roberthbailey
+    - rsdcastro

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -11,6 +11,7 @@ aliases:
     - krousey
     - luxas
     - roberthbailey
+    - rsdcastro
   kube-deploy-maintainers:
     - jessicaochen
     - kris-nova

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -11,7 +11,6 @@ aliases:
     - krousey
     - luxas
     - roberthbailey
-    - rsdcastro
   kube-deploy-maintainers:
     - jessicaochen
     - kris-nova

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -11,10 +11,10 @@ aliases:
     - krousey
     - luxas
     - roberthbailey
+    - rsdcastro
   kube-deploy-maintainers:
     - jessicaochen
     - kris-nova
     - krousey
     - medinatiger
     - roberthbailey
-    - rsdcastro

--- a/cluster-api-gcp/.gitignore
+++ b/cluster-api-gcp/.gitignore
@@ -1,2 +1,3 @@
 cluster-api-gcp
 machine-controller/machine-controller
+machines.yaml

--- a/cluster-api-gcp/CONTRIBUTING.md
+++ b/cluster-api-gcp/CONTRIBUTING.md
@@ -8,9 +8,9 @@ If you don't have a Google Cloud Project, please [create one](https://cloud.goog
 
 In order to use the GCP machine controller, you need to configure the credentials so that the code has access to the GCP project where resources will be created.
 
-For that, make sure that the environment variable `GOOGLE_APPLICATION_CREDENTIALS` is set pointing to valid service account credentials.
-
-In case you don't have it set, follow the [instructions on Google Cloud Platform site](https://cloud.google.com/docs/authentication/getting-started) to have it set up.
+Steps to follow:
+1. Verify that the environment variable `GOOGLE_APPLICATION_CREDENTIALS` is set pointing to valid service account credentials
+2. If not set, follow the [instructions on Google Cloud Platform site](https://cloud.google.com/docs/authentication/getting-started) to have it set up.
 
 ## Install Google Cloud SDK (gcloud)
 
@@ -19,18 +19,18 @@ Google Cloud SDK (gcloud) will be helpful for two reasons:
 -  Set configuration values that will be used during development (like project name).
 
 Steps to follow:
-1.  Install as per [Cloud SDK instructions](https://cloud.google.com/sdk/)
-2.  Configure GCP project
+1.  Install as per [Cloud SDK instructions](https://cloud.google.com/sdk/);
+2.  Configure Cloud SDK to point to the GCP project you will be using.
 
-```bash
-$ gcloud auth login
-$ gcloud config set project <GCP_PROJECT_ID>
-```
+    ```bash
+    $ gcloud auth login
+    $ gcloud config set project <GCP_PROJECT_ID>
+    ```
 
 ## Install Docker
 
-1. Install Docker
-2. Make sure your user can execute docker commmands (without sudo)
+1. Install [Docker](https://docs.docker.com/install/) on your machine;
+2. Make sure your user can execute docker commmands (without sudo). This is a way to test it:
 ```bash
 $ docker run hello-world
 

--- a/cluster-api-gcp/CONTRIBUTING.md
+++ b/cluster-api-gcp/CONTRIBUTING.md
@@ -43,7 +43,7 @@ This message shows that your installation appears to be working correctly.
 
 ```bash
 $ cd $GOPATH/src/k8s.io/
-$ git clone https://github.com/<github-username>/kube-deploy.git
+$ git clone https://github.com/<GITHUB-USERNAME>/kube-deploy.git
 $ cd kube-deploy/cluster-api-gcp/
 $ go build
 ```

--- a/cluster-api-gcp/CONTRIBUTING.md
+++ b/cluster-api-gcp/CONTRIBUTING.md
@@ -1,15 +1,54 @@
 # Contributing Guidelines
 
+## Google Cloud Project
+
+If you don't have a Google Cloud Project, please [create one](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
+
+## Set GCP Credentials
+
+In order to use the GCP machine controller, you need to configure the credentials so that the code has access to the GCP project where resources will be created.
+
+For that, make sure that the environment variable `GOOGLE_APPLICATION_CREDENTIALS` is set pointing to valid service account credentials.
+
+In case you don't have it set, follow the [instructions on Google Cloud Platform site](https://cloud.google.com/docs/authentication/getting-started) to have it set up.
+
+## Install Google Cloud SDK (gcloud)
+
+Google Cloud SDK (gcloud) will be helpful for two reasons:
+-  Inspect GCP resources during development;
+-  Set configuration values that will be used during development (like project name).
+
+Steps to follow:
+1.  Install as per [Cloud SDK instructions](https://cloud.google.com/sdk/)
+2.  Configure GCP project
+
+```bash
+$ gcloud auth login
+$ gcloud config set project <GCP_PROJECT_ID>
+```
+
+## Install Docker
+
+1. Install Docker
+2. Make sure your user can execute docker commmands (without sudo)
+```bash
+$ docker run hello-world
+
+Hello from Docker!
+This message shows that your installation appears to be working correctly.
+...
+```
+
 ## Build
 
 ```bash
 $ cd $GOPATH/src/k8s.io/
-$ git clone git@github.com:kubernetes/kube-deploy.git
+$ git clone https://github.com/kubernetes/kube-deploy.git
 $ cd kube-deploy/cluster-api-gcp/
 $ go build
 ```
 
-This will create a binary `cluster-api-gcp` that you can use to manage a GCP cluster.
+This will create a binary `cluster-api-gcp` in the same directory. You can use that binary to manage a GCP cluster.
 
 ## Developing
 
@@ -21,16 +60,19 @@ $ ./cluster-api-gcp delete
 
 After making changes to the machine controller or the actuator, you need to follow these two steps:
 
-1. Rebuild the machine-controller image. Modify the `machine-controller/Makefile` and change the `PROJECT` to your own GCP project. This is important so you don't overwrite the official image. Also change `machineControllerImage` in `cloud/google/pods.go` to the new image path (make sure the version in the Makefile and `pods.go` match if you want to use the new image). Then, rebuild and push the image.
+1. Rebuild the machine-controller image. Also change `machineControllerImage` in `cloud/google/pods.go` to the new image path (make sure the version in the Makefile and `pods.go` match if you want to use the new image). Then, rebuild and push the image.
 
 	```bash
 	$ cd machine-controller
 	$ make push fix-image-permissions
 	```
 
+NOTE: that the image will be pushed to `gcr.io/$(GCLOUD_PROJECT)/machine-controller`. Image storage is a billable resource.
+
 2. Rebuild cluster-api-gcp
 
 	```bash
+    $ cd ..
 	$ go build
 	```
 
@@ -39,6 +81,21 @@ The new `cluster-api-gcp` will have your changes.
 ## Testing
 
 We do not have unit tests or integration tests currently. For any changes, it is recommended that you test a create-edit-delete sequence using the new machine controller image and the new `cluster-api-gcp` binary.
+
+1. Generate machines configuration file.
+
+This step is necessary to include the project name (as configured in Google Cloud SDK) in the yaml file.
+
+	```bash
+	$ ./generate-yaml.sh
+	```
+
+If Cloud SDK isn't configure, you will see an error like the one below:
+
+	```bash
+	$ ./generate-yaml.sh
+    ERROR: (gcloud.config.get-value) Section [core] has no property [project].
+	```
 
 1. Create a cluster
 

--- a/cluster-api-gcp/CONTRIBUTING.md
+++ b/cluster-api-gcp/CONTRIBUTING.md
@@ -43,7 +43,7 @@ This message shows that your installation appears to be working correctly.
 
 ```bash
 $ cd $GOPATH/src/k8s.io/
-$ git clone https://github.com/<GITHUB-USERNAME>/kube-deploy.git
+$ git clone https://github.com/<GITHUB_USERNAME>/kube-deploy.git
 $ cd kube-deploy/cluster-api-gcp/
 $ go build
 ```

--- a/cluster-api-gcp/CONTRIBUTING.md
+++ b/cluster-api-gcp/CONTRIBUTING.md
@@ -39,12 +39,22 @@ This message shows that your installation appears to be working correctly.
 ...
 ```
 
-## Build
+## Fetch Source Code
 
+1. Fork [kube-deploy repo](https://github.com/kubernetes/kube-deploy). If it's your first time forking, please take a look at [GitHub Repo instructions](https://help.github.com/articles/fork-a-repo/). The general [Kubernetes GitHub workflow](https://github.com/kubernetes/community/blob/master/contributors/guide/github-workflow.md) is helpful here too if you're getting started.
+
+2. Clone Repo Locally
 ```bash
 $ cd $GOPATH/src/k8s.io/
 $ git clone https://github.com/<GITHUB_USERNAME>/kube-deploy.git
 $ cd kube-deploy/cluster-api-gcp/
+$ go build
+```
+
+## Build
+
+```bash
+$ cd $GOPATH/src/k8s.io/kube-deploy/cluster-api-gcp/
 $ go build
 ```
 
@@ -90,7 +100,7 @@ This step is necessary to include the project name (as configured in Google Clou
 	$ ./generate-yaml.sh
 	```
 
-If Cloud SDK isn't configure, you will see an error like the one below:
+If Cloud SDK isn't configured, you will see an error like the one below:
 
 	```bash
 	$ ./generate-yaml.sh

--- a/cluster-api-gcp/CONTRIBUTING.md
+++ b/cluster-api-gcp/CONTRIBUTING.md
@@ -43,7 +43,7 @@ This message shows that your installation appears to be working correctly.
 
 ```bash
 $ cd $GOPATH/src/k8s.io/
-$ git clone https://github.com/kubernetes/kube-deploy.git
+$ git clone https://github.com/<github-username>/kube-deploy.git
 $ cd kube-deploy/cluster-api-gcp/
 $ go build
 ```

--- a/cluster-api-gcp/generate-yaml.sh
+++ b/cluster-api-gcp/generate-yaml.sh
@@ -17,7 +17,7 @@ while test $# -gt 0; do
             echo " "
             echo "options:"
             echo "-h, --help                show brief help"
-            echo "-f, --force-overwrite     overwrite if file to be generated already exists"
+            echo "-f, --force-overwrite     if file to be generated already exists, force script to overwrite it"
             exit 0
             ;;
           -f)

--- a/cluster-api-gcp/generate-yaml.sh
+++ b/cluster-api-gcp/generate-yaml.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+GCLOUD_PROJECT=$(gcloud config get-value project)
+
+TEMPLATE_FILE=machines.yaml.template
+GENERATED_FILE=machines.yaml
+
+if [ -f $GENERATED_FILE ]; then
+  echo File $GENERATED_FILE already exists. Delete it manually before running this script.
+  exit 1
+fi
+
+sed -e "s/\$GCLOUD_PROJECT/$GCLOUD_PROJECT/" $TEMPLATE_FILE > $GENERATED_FILE

--- a/cluster-api-gcp/generate-yaml.sh
+++ b/cluster-api-gcp/generate-yaml.sh
@@ -5,8 +5,36 @@ GCLOUD_PROJECT=$(gcloud config get-value project)
 
 TEMPLATE_FILE=machines.yaml.template
 GENERATED_FILE=machines.yaml
+OVERWRITE=0
 
-if [ -f $GENERATED_FILE ]; then
+SCRIPT=$(basename $0)
+while test $# -gt 0; do
+        case "$1" in
+          -h|--help)
+            echo "$SCRIPT - generates input yaml files for Cluster API on Google Cloud Platform"
+            echo " "
+            echo "$SCRIPT [options]"
+            echo " "
+            echo "options:"
+            echo "-h, --help                show brief help"
+            echo "-f, --force-overwrite     overwrite if file to be generated already exists"
+            exit 0
+            ;;
+          -f)
+            OVERWRITE=1
+            shift
+            ;;
+          --force-overwrite)
+            OVERWRITE=1
+            shift
+            ;;
+          *)
+            break
+            ;;
+        esac
+done
+
+if [ $OVERWRITE -ne 1 ] && [ -f $GENERATED_FILE ]; then
   echo File $GENERATED_FILE already exists. Delete it manually before running this script.
   exit 1
 fi

--- a/cluster-api-gcp/machine-controller/Makefile
+++ b/cluster-api-gcp/machine-controller/Makefile
@@ -1,4 +1,4 @@
-PROJECT=k8s-cluster-api
+GCLOUD_PROJECT ?= $(shell /usr/bin/gcloud config get-value project1)
 NAME=machine-controller
 VERSION=0.19
 
@@ -6,13 +6,13 @@ staticbuild:
 	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' .
 
 image: staticbuild
-	docker build -t "gcr.io/$(PROJECT)/$(NAME):$(VERSION)" .
+	docker build -t "gcr.io/$(GCLOUD_PROJECT)/$(NAME):$(VERSION)" .
 
 push: image
-	gcloud docker -- push "gcr.io/$(PROJECT)/$(NAME):$(VERSION)"
+	gcloud docker -- push "gcr.io/$(GCLOUD_PROJECT)/$(NAME):$(VERSION)"
 
 fix-image-permissions:
-	gsutil acl ch -u AllUsers:READ gs://artifacts.$(PROJECT).appspot.com
-	gsutil -m acl ch -r -u AllUsers:READ gs://artifacts.$(PROJECT).appspot.com
+	gsutil acl ch -u AllUsers:READ gs://artifacts.$(GCLOUD_PROJECT).appspot.com
+	gsutil -m acl ch -r -u AllUsers:READ gs://artifacts.$(GCLOUD_PROJECT).appspot.com
 
 .PHONY: image push staticbuild fix-image-permissions

--- a/cluster-api-gcp/machine-controller/Makefile
+++ b/cluster-api-gcp/machine-controller/Makefile
@@ -1,4 +1,4 @@
-GCLOUD_PROJECT ?= $(shell /usr/bin/gcloud config get-value project1)
+GCLOUD_PROJECT ?= $(shell /usr/bin/gcloud config get-value project)
 NAME=machine-controller
 VERSION=0.19
 

--- a/cluster-api-gcp/machines.yaml.template
+++ b/cluster-api-gcp/machines.yaml.template
@@ -10,7 +10,7 @@ items:
       {
         "apiVersion": "gceproviderconfig/v1alpha1",
         "kind": "GCEProviderConfig",
-        "project": "jesschen-gke-dev",
+        "project": "$GCLOUD_PROJECT",
         "zone": "us-central1-f",
         "machineType": "n1-standard-2",
         "image": "projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts"
@@ -34,7 +34,7 @@ items:
       {
         "apiVersion": "gceproviderconfig/v1alpha1",
         "kind": "GCEProviderConfig",
-        "project": "jesschen-gke-dev",
+        "project": "$GCLOUD_PROJECT",
         "zone": "us-central1-f",
         "machineType": "n1-standard-1",
         "image": "projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts"


### PR DESCRIPTION
Update CONTRIBUTING to include required steps, like setting GCP credentials and installing Docker.
Also add gcloud step as it's very helpful if one is developing against GCP and gives us a central project ID store.
Update places where hard-coded projects were used to fetch it from gcloud.