### PR TITLE
Reconcile instructions in README.md and CONTRIBUTING.md 

### DIFF
--- a/cluster-api-gcp/CONTRIBUTING.md
+++ b/cluster-api-gcp/CONTRIBUTING.md
@@ -42,9 +42,9 @@ Steps to follow:
 
 The alternative is to set the client credentials via gcloud by executing the command line below.
 
-    ```bash
-    $ gcloud auth application-default login
-    ```
+```bash
+$ gcloud auth application-default login
+```
 
 ## Install Docker
 

--- a/cluster-api-gcp/CONTRIBUTING.md
+++ b/cluster-api-gcp/CONTRIBUTING.md
@@ -115,16 +115,16 @@ We do not have unit tests or integration tests currently. For any changes, it is
 
 This step is necessary to include the project name (as configured in Google Cloud SDK) in the yaml file.
 
-	```bash
-	$ ./generate-yaml.sh
-	```
+```bash
+$ ./generate-yaml.sh
+```
 
 If Cloud SDK isn't configured, you will see an error like the one below:
 
-	```bash
-	$ ./generate-yaml.sh
-    ERROR: (gcloud.config.get-value) Section [core] has no property [project].
-	```
+```bash
+$ ./generate-yaml.sh
+ERROR: (gcloud.config.get-value) Section [core] has no property [project].
+```
 
 1. Create a cluster
 

--- a/cluster-api-gcp/CONTRIBUTING.md
+++ b/cluster-api-gcp/CONTRIBUTING.md
@@ -26,7 +26,21 @@ Steps to follow:
     $ gcloud config set project <GCP_PROJECT_ID>
     ```
 
-3.  Set the client credentials to be used by Cluster API to create resources.
+## Set GCP Credentials
+
+In order to use the GCP machine controller, you need to configure the credentials so that the code has access to the GCP project where resources will be created.
+
+You can set it in two ways, as explained below.
+
+### Environment Variable GOOGLE_APPLICATION_CREDENTIALS
+
+Steps to follow:
+1. Verify that the environment variable `GOOGLE_APPLICATION_CREDENTIALS` is set pointing to valid service account credentials
+2. If not set, follow the [instructions on Google Cloud Platform site](https://cloud.google.com/docs/authentication/getting-started) to have it set up.
+
+### Login Using Cloud SDK
+
+The alternative is to set the client credentials via gcloud by executing the command line below.
 
     ```bash
     $ gcloud auth application-default login

--- a/cluster-api-gcp/CONTRIBUTING.md
+++ b/cluster-api-gcp/CONTRIBUTING.md
@@ -1,10 +1,12 @@
 # Contributing Guidelines
 
-## Google Cloud Project
+## Prerequisites
+
+### Google Cloud Project
 
 If you don't have a Google Cloud Project, please [create one](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
 
-## Create Firewall
+### Create Firewall
 
 Create a firewall rule to allow communication from kubectl (and nodes) to the control plane.
 
@@ -12,7 +14,7 @@ Create a firewall rule to allow communication from kubectl (and nodes) to the co
    gcloud compute firewall-rules create cluster-api-open --allow=TCP:443 --source-ranges=0.0.0.0/0 --target-tags='https-server'
    ```
 
-## Install Google Cloud SDK (gcloud)
+### Install Google Cloud SDK (gcloud)
 
 Google Cloud SDK (gcloud) will be helpful for two reasons:
 -  Inspect GCP resources during development;
@@ -26,19 +28,19 @@ Steps to follow:
     $ gcloud config set project <GCP_PROJECT_ID>
     ```
 
-## Set GCP Credentials
+### Set GCP Credentials
 
 In order to use the GCP machine controller, you need to configure the credentials so that the code has access to the GCP project where resources will be created.
 
 You can set it in two ways, as explained below.
 
-### Environment Variable GOOGLE_APPLICATION_CREDENTIALS
+#### Environment Variable GOOGLE_APPLICATION_CREDENTIALS
 
 Steps to follow:
 1. Verify that the environment variable `GOOGLE_APPLICATION_CREDENTIALS` is set pointing to valid service account credentials
 2. If not set, follow the [instructions on Google Cloud Platform site](https://cloud.google.com/docs/authentication/getting-started) to have it set up.
 
-### Login Using Cloud SDK
+#### Login Using Cloud SDK
 
 The alternative is to set the client credentials via gcloud by executing the command line below.
 
@@ -46,7 +48,7 @@ The alternative is to set the client credentials via gcloud by executing the com
 $ gcloud auth application-default login
 ```
 
-## Install Docker
+### Install Docker
 
 1. Install [Docker](https://docs.docker.com/install/) on your machine;
 2. Make sure your user can execute docker commmands (without sudo). This is a way to test it:
@@ -143,3 +145,18 @@ ERROR: (gcloud.config.get-value) Section [core] has no property [project].
 	```bash
 	$ ./cluster-api-gcp delete
 	```
+
+## Updating vendor directory for cluster-api changes
+
+For changes to dependencies, like [cluster-api](https://github.com/kubernetes/kube-deploy/tree/master/cluster-api), follow the steps:
+
+1. Make sure you have dep installed (or install it from [here])
+
+2. Run ```dep ensure -update``` as follows:
+
+```bash
+$ cd $GOPATH/src/k8s.io/kube-deploy/cluster-api-gcp/
+$ dep ensure -update k8s.io/kube-deploy
+```
+
+3. Submit a pull request with the updated files.

--- a/cluster-api-gcp/CONTRIBUTING.md
+++ b/cluster-api-gcp/CONTRIBUTING.md
@@ -4,13 +4,13 @@
 
 If you don't have a Google Cloud Project, please [create one](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
 
-## Set GCP Credentials
+## Create Firewall
 
-In order to use the GCP machine controller, you need to configure the credentials so that the code has access to the GCP project where resources will be created.
+Create a firewall rule to allow communication from kubectl (and nodes) to the control plane.
 
-Steps to follow:
-1. Verify that the environment variable `GOOGLE_APPLICATION_CREDENTIALS` is set pointing to valid service account credentials
-2. If not set, follow the [instructions on Google Cloud Platform site](https://cloud.google.com/docs/authentication/getting-started) to have it set up.
+   ```bash
+   gcloud compute firewall-rules create cluster-api-open --allow=TCP:443 --source-ranges=0.0.0.0/0 --target-tags='https-server'
+   ```
 
 ## Install Google Cloud SDK (gcloud)
 
@@ -23,8 +23,13 @@ Steps to follow:
 2.  Configure Cloud SDK to point to the GCP project you will be using.
 
     ```bash
-    $ gcloud auth login
     $ gcloud config set project <GCP_PROJECT_ID>
+    ```
+
+3.  Set the client credentials to be used by Cluster API to create resources.
+
+    ```bash
+    $ gcloud auth application-default login
     ```
 
 ## Install Docker

--- a/cluster-api-gcp/README.md
+++ b/cluster-api-gcp/README.md
@@ -6,33 +6,15 @@ The Cluster API GCP prototype implements the [Cluster API](https://github.com/ku
 
 ### Prerequisites
 
-* `kubectl` is required, see [here](http://kubernetes.io/docs/user-guide/prereqs/).
-* The [Google Cloud SDK](https://cloud.google.com/sdk/downloads) needs to be installed.
-* You will need to have a GCP account.
-* Create a firewall rule to allow communication from kubectl (and nodes) to the control plane.
-
-   ```bash
-   gcloud compute firewall-rules create cluster-api-open --allow=TCP:443 --source-ranges=0.0.0.0/0 --target-tags='https-server'
-   ```
-
-
-### Building
-
-```bash
-$ cd $GOPATH/src/k8s.io/
-$ git clone git@github.com:kubernetes/kube-deploy.git
-$ cd kube-deploy/cluster-api-gcp
-$ go build
-```
-
+Follow the steps listed at [CONTRIBUTING.md](https://github.com/kubernetes/kube-deploy/blob/master/cluster-api-gcp/CONTRIBUTING.md) to:
+1. Build the `cluster-api-gcp` tool
+2. Generate base `machines.yaml` file configured for your GCP project
 
 ### Creating a cluster
 
-1. Follow the above steps to clone the repository and build the `cluster-api-gcp` tool.
-1. Update `machines.yaml` to give your preferred GCP project/zone in
+1. *Optional* update `machines.yaml` to give your preferred GCP zone in
 each machine's `providerConfig` field.
-   - *Optional*: Update `cluster.yaml` to set a custom cluster name.
-1. Run `gcloud auth application-default login` to get default credentials.
+1. *Optional*: Update `cluster.yaml` to set a custom cluster name.
 1. Create a cluster: `./cluster-api-gcp create -c cluster.yaml -m machines.yaml`
 
 During cluster creation, you can watch the machine resources get created in Kubernetes,


### PR DESCRIPTION
Reconcile instructions to avoid duplicate/conflicting info. In particular, add firewall instructions and use gcloud to help with the credentials (avoiding some manual steps).