### PR TITLE
Wait for service account before running machine controller

### DIFF
--- a/cluster-api/util/util.go
+++ b/cluster-api/util/util.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/golang/glog"
 	"k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	clusterv1 "k8s.io/kube-deploy/cluster-api/api/cluster/v1alpha1"
 	"k8s.io/kube-deploy/cluster-api/client"
@@ -105,6 +106,19 @@ func NewApiClient(configPath string) (*client.ClusterAPIV1Alpha1Client, error) {
 	}
 
 	c, err := client.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+func NewKubernetesClient(configPath string) (*kubernetes.Clientset, error) {
+	config, err := clientcmd.BuildConfigFromFlags("", configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, err
 	}

--- a/cluster-api/util/util.go
+++ b/cluster-api/util/util.go
@@ -113,6 +113,10 @@ func NewApiClient(configPath string) (*client.ClusterAPIV1Alpha1Client, error) {
 }
 
 func NewKubernetesClient(configPath string) (*kubernetes.Clientset, error) {
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		return nil, fmt.Errorf("kubectl config file %s doesn't exist. Is kubectl configured to access a cluster?", configPath)
+	}
+
 	config, err := clientcmd.BuildConfigFromFlags("", configPath)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes #558 

We'll need to do is update the vendor lock in cluster-api-gcp after this PR is merged.