### PR TITLE
(opt) assign an IAM instance profile to EC2 instances

### DIFF
--- a/imagebuilder/pkg/imagebuilder/aws.go
+++ b/imagebuilder/pkg/imagebuilder/aws.go
@@ -453,6 +453,9 @@ func (c *AWSCloud) CreateInstance() (Instance, error) {
 	request.ImageId = aws.String(c.config.ImageID)
 	request.KeyName = aws.String(sshKeyName)
 	request.InstanceType = aws.String(c.config.InstanceType)
+	if c.config.InstanceProfile != "" {
+		request.IamInstanceProfile = &ec2.IamInstanceProfileSpecification{Name: aws.String(c.config.InstanceProfile)}
+	}
 	request.NetworkInterfaces = []*ec2.InstanceNetworkInterfaceSpecification{
 		{
 			DeviceIndex:              aws.Int64(0),

--- a/imagebuilder/pkg/imagebuilder/config.go
+++ b/imagebuilder/pkg/imagebuilder/config.go
@@ -18,6 +18,8 @@ type Config struct {
 	SSHPublicKey  string
 	SSHPrivateKey string
 
+	InstanceProfile string
+
 	// Tags to add to the image
 	Tags map[string]string
 }
@@ -29,6 +31,8 @@ func (c *Config) InitDefaults() {
 	c.SSHUsername = "admin"
 	c.SSHPublicKey = "~/.ssh/id_rsa.pub"
 	c.SSHPrivateKey = "~/.ssh/id_rsa"
+
+	c.InstanceProfile = ""
 
 	setupCommands := []string{
 		"sudo apt-get update",


### PR DESCRIPTION
If the `InstanceProfile` option is included in the configuration file,
assign an IAM instance profile to the instance used to build the AMI.

Example uses:

* access external secrets/resources
* pre-cache private Docker images from ECR (my use case!)

I'm not sufficiently familiar with GCP to contribute a functionally
matching feature for that platform, unfortunately. Sorry.

I haven't completed CLA paperwork yet but will do ASAP.