### PR TITLE
Add a couple of scripts for CI

### DIFF
--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT=$(dirname "${BASH_SOURCE}")/..
+
+go build \
+   "${REPO_ROOT}"/cluster-api/... \
+   "${REPO_ROOT}"/cluster-api-gcp/... \
+   "${REPO_ROOT}"/ext-apiserver/...

--- a/scripts/ci-test.sh
+++ b/scripts/ci-test.sh
@@ -1,0 +1,27 @@
+
+#!/bin/bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT=$(dirname "${BASH_SOURCE}")/..
+
+go test \
+   "${REPO_ROOT}"/cluster-api/... \
+   "${REPO_ROOT}"/cluster-api-gcp/... \
+   "${REPO_ROOT}"/ext-apiserver/...


### PR DESCRIPTION
**What this PR does / why we need it**: This is the start of build scripts for basic CI building and testing. 

**Special notes for your reviewer**: This does not turn on CI for this repo, just defines basic steps for CI to run. After this is in, I will work on getting CI to use this.

@kubernetes/kube-deploy-reviewers
