### PR TITLE
Fix the machine controller tests

### DIFF
--- a/ext-apiserver/pkg/controller/machine/machine_suite_test.go
+++ b/ext-apiserver/pkg/controller/machine/machine_suite_test.go
@@ -1,4 +1,3 @@
-
 /*
 Copyright 2018 The Kubernetes Authors.
 
@@ -15,22 +14,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
 package machine_test
 
 import (
 	"testing"
 
+	"github.com/kubernetes-incubator/apiserver-builder/pkg/test"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/rest"
-	"github.com/kubernetes-incubator/apiserver-builder/pkg/test"
 
 	"k8s.io/kube-deploy/ext-apiserver/pkg/apis"
 	"k8s.io/kube-deploy/ext-apiserver/pkg/client/clientset_generated/clientset"
-	"k8s.io/kube-deploy/ext-apiserver/pkg/openapi"
-	"k8s.io/kube-deploy/ext-apiserver/pkg/controller/sharedinformers"
+	cfg "k8s.io/kube-deploy/ext-apiserver/pkg/controller/config"
 	"k8s.io/kube-deploy/ext-apiserver/pkg/controller/machine"
+	"k8s.io/kube-deploy/ext-apiserver/pkg/controller/sharedinformers"
+	"k8s.io/kube-deploy/ext-apiserver/pkg/openapi"
 )
 
 var testenv *test.TestEnvironment
@@ -49,6 +48,7 @@ var _ = BeforeSuite(func() {
 	testenv = test.NewTestEnvironment()
 	config = testenv.Start(apis.GetAllApiBuilders(), openapi.GetOpenAPIDefinitions)
 	cs = clientset.NewForConfigOrDie(config)
+	cfg.ControllerConfig.Cloud = "test"
 
 	shutdown = make(chan struct{})
 	si = sharedinformers.NewSharedInformers(config, shutdown)


### PR DESCRIPTION
Added config initialization to make it use the logging actuator, and
changed it to have a cluster created as well.

**What this PR does / why we need it**: So our tests don't panic and crash.

@kubernetes/kube-deploy-reviewers
