### PR TITLE
Clear finalizer in test so it can actually delete

### DIFF
--- a/ext-apiserver/pkg/apis/cluster/v1alpha1/machine_types_test.go
+++ b/ext-apiserver/pkg/apis/cluster/v1alpha1/machine_types_test.go
@@ -1,4 +1,3 @@
-
 /*
 Copyright 2018 The Kubernetes Authors.
 
@@ -14,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
 
 package v1alpha1_test
 
@@ -68,6 +66,9 @@ var _ = Describe("Machine", func() {
 				Expect(actual.Spec).To(Equal(expected.Spec))
 
 				By("deleting the item for delete requests")
+				actual.Finalizers = nil
+				_, err = client.Update(actual)
+				Expect(err).ShouldNot(HaveOccurred())
 				err = client.Delete(instance.Name, &metav1.DeleteOptions{})
 				Expect(err).ShouldNot(HaveOccurred())
 				result, err = client.List(metav1.ListOptions{})


### PR DESCRIPTION
**What this PR does / why we need it**: It fixes a unit test.

ref: #544 

@kubernetes/kube-deploy-reviewers
