### PR TITLE
#571 generate random name, if generateName field set in spec

### DIFF
--- a/cluster-api-gcp/deploy/deploy_helper.go
+++ b/cluster-api-gcp/deploy/deploy_helper.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/golang/glog"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/storage/names"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/kube-deploy/cluster-api-gcp/util"
 	clusterv1 "k8s.io/kube-deploy/cluster-api/api/cluster/v1alpha1"
@@ -53,7 +54,9 @@ func (d *deployer) createCluster(c *clusterv1.Cluster, machines []*clusterv1.Mac
 	}
 
 	if master.GetName() == "" {
-		master.Name = master.GetGenerateName() + c.GetName()
+		/* Need the generate master name here, master object gets created before submitting CRD to API server.
+		However, in case of node names, we submit the CRD to API server which generates the name on validation.*/
+		master.Name = names.SimpleNameGenerator.GenerateName(master.GetGenerateName()) + "-" + c.GetName()
 	}
 
 	glog.Infof("Starting cluster creation %s", c.GetName())


### PR DESCRIPTION
Fixes #571 

Concatenate random name, with generated name, this works currently for node names, but not for master node names. This PR fixes this.