### PR TITLE
bake deploy template into gcp-deployer

### DIFF
--- a/ext-apiserver/cloud/google/config/configtemplate.go
+++ b/ext-apiserver/cloud/google/config/configtemplate.go
@@ -1,4 +1,22 @@
+/*
+Copyright 2017 The Kubernetes Authors.
 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+const ClusterAPIDeployConfigTemplate = `
 apiVersion: apiregistration.k8s.io/v1beta1
 kind: APIService
 metadata:
@@ -240,3 +258,4 @@ metadata:
 data:
   tls.crt: {{ .TlsCrt }}
   tls.key: {{ .TlsKey }}
+`

--- a/ext-apiserver/cloud/google/pods.go
+++ b/ext-apiserver/cloud/google/pods.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	"k8s.io/kube-deploy/ext-apiserver/cloud/google/config"
 )
 
 var machineControllerImage = "gcr.io/k8s-cluster-api/apiserver-controller:0.1"
@@ -79,7 +80,7 @@ func getApiServerCerts() (*caCertParams, error) {
 }
 
 func CreateApiServerAndController(token string) error {
-	tmpl, err := template.ParseFiles("cloud/google/config/apiserver.yaml")
+	tmpl, err := template.New("config").Parse(config.ClusterAPIDeployConfigTemplate)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The template was a on-disk file. It implies the gcp-deployer (old
cluster-api-gcp) has to be running from root directory.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
It tries to eliminate the dependency in which gcp-deployer has to be running from root directory of the project. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
It just eliminate one of the dependency. There will be more PR coming to address the remaining dependency.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
