### PR TITLE
Update client dependency to fix a race condition

### DIFF
--- a/ext-apiserver/Gopkg.lock
+++ b/ext-apiserver/Gopkg.lock
@@ -912,7 +912,7 @@
     "util/jsonpath",
     "util/workqueue"
   ]
-  revision = "3a46b5de730a74e064197a157c96c2d29724a677"
+  revision = "04b7cf8ad6185c7168751d613c638c94f60711be"
 
 [[projects]]
   branch = "master"
@@ -928,6 +928,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a54378e03bb6bcaf5f194ad9658162214b46cf41e027b38406b3e86c157b276f"
+  inputs-digest = "a45b31318bfde6352f707acfd63eeab3cf41e70047bc18e8672dcccd9bd002fc"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/ext-apiserver/vendor/k8s.io/client-go/Godeps/Godeps.json
+++ b/ext-apiserver/vendor/k8s.io/client-go/Godeps/Godeps.json
@@ -476,191 +476,191 @@
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/equality",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/errors",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/meta",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/resource",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/internalversion",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1alpha1",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/conversion",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/conversion/queryparams",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/conversion/unstructured",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/fields",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/labels",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/schema",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/json",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/protobuf",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/recognizer",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/streaming",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/versioning",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/selection",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/types",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/cache",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/clock",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/diff",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/errors",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/framer",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/httpstream",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/httpstream/spdy",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/intstr",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/json",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/mergepatch",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/net",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/remotecommand",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/runtime",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/sets",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/strategicpatch",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/validation",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/validation/field",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/wait",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/yaml",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/version",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/watch",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/third_party/forked/golang/json",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/third_party/forked/golang/netutil",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/third_party/forked/golang/reflect",
-			"Rev": "bc110fd540ab678abbf2bc71d9ce908eb9325ef6"
+			"Rev": "4972c8e335e32ab65ba45bde0a99c6544c8a8e4c"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/common",

--- a/ext-apiserver/vendor/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/ext-apiserver/vendor/k8s.io/client-go/tools/cache/shared_informer.go
@@ -328,7 +328,7 @@ func (s *sharedIndexInformer) AddEventHandlerWithResyncPeriod(handler ResourceEv
 	s.blockDeltas.Lock()
 	defer s.blockDeltas.Unlock()
 
-	s.processor.addAndStartListener(listener)
+	s.processor.addListener(listener)
 	for _, item := range s.indexer.List() {
 		listener.add(addNotification{newObj: item})
 	}
@@ -366,6 +366,7 @@ func (s *sharedIndexInformer) HandleDeltas(obj interface{}) error {
 }
 
 type sharedProcessor struct {
+	listenersStarted bool
 	listenersLock    sync.RWMutex
 	listeners        []*processorListener
 	syncingListeners []*processorListener
@@ -373,20 +374,15 @@ type sharedProcessor struct {
 	wg               wait.Group
 }
 
-func (p *sharedProcessor) addAndStartListener(listener *processorListener) {
-	p.listenersLock.Lock()
-	defer p.listenersLock.Unlock()
-
-	p.addListenerLocked(listener)
-	p.wg.Start(listener.run)
-	p.wg.Start(listener.pop)
-}
-
 func (p *sharedProcessor) addListener(listener *processorListener) {
 	p.listenersLock.Lock()
 	defer p.listenersLock.Unlock()
 
 	p.addListenerLocked(listener)
+	if p.listenersStarted {
+		p.wg.Start(listener.run)
+		p.wg.Start(listener.pop)
+	}
 }
 
 func (p *sharedProcessor) addListenerLocked(listener *processorListener) {
@@ -417,6 +413,7 @@ func (p *sharedProcessor) run(stopCh <-chan struct{}) {
 			p.wg.Start(listener.run)
 			p.wg.Start(listener.pop)
 		}
+		p.listenersStarted = true
 	}()
 	<-stopCh
 	p.listenersLock.RLock()

--- a/ext-apiserver/vendor/k8s.io/client-go/tools/cache/shared_informer_test.go
+++ b/ext-apiserver/vendor/k8s.io/client-go/tools/cache/shared_informer_test.go
@@ -251,3 +251,15 @@ func TestResyncCheckPeriod(t *testing.T) {
 		t.Errorf("expected %d, got %d", e, a)
 	}
 }
+
+// verify that https://github.com/kubernetes/kubernetes/issues/59822 is fixed
+func TestSharedInformerInitializationRace(t *testing.T) {
+	source := fcache.NewFakeControllerSource()
+	informer := NewSharedInformer(source, &v1.Pod{}, 1*time.Second).(*sharedIndexInformer)
+	listener := newTestListener("raceListener", 0)
+
+	stop := make(chan struct{})
+	go informer.AddEventHandlerWithResyncPeriod(listener, listener.resyncPeriod)
+	go informer.Run(stop)
+	close(stop)
+}


### PR DESCRIPTION
Ran dep ensure -update k8s.io/client-go in the ext-apiserver directory.

**What this PR does / why we need it**: Pulls in a fix for a race condition that is making tests flake.

@kubernetes/kube-deploy-reviewers
