### PR TITLE
initial implementation of machineset controller

### DIFF
--- a/ext-apiserver/pkg/apis/cluster/v1alpha1/machineset_types.go
+++ b/ext-apiserver/pkg/apis/cluster/v1alpha1/machineset_types.go
@@ -26,7 +26,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-
 	"k8s.io/kube-deploy/ext-apiserver/pkg/apis/cluster"
 	"k8s.io/kube-deploy/ext-apiserver/pkg/apis/cluster/common"
 )
@@ -140,6 +139,14 @@ func (MachineSetStrategy) Validate(ctx request.Context, obj runtime.Object) fiel
 // DefaultingFunction sets default MachineSet field values
 func (MachineSetSchemeFns) DefaultingFunction(o interface{}) {
 	obj := o.(*MachineSet)
-	// set default field values here
 	log.Printf("Defaulting fields for MachineSet %s\n", obj.Name)
+
+	if obj.Spec.Replicas == nil {
+		obj.Spec.Replicas = new(int32)
+		*obj.Spec.Replicas = 1
+	}
+
+	if len(obj.Namespace) == 0 {
+		obj.Namespace = metav1.NamespaceDefault
+	}
 }

--- a/ext-apiserver/pkg/apis/cluster/v1alpha1/v1alpha1_suite_test.go
+++ b/ext-apiserver/pkg/apis/cluster/v1alpha1/v1alpha1_suite_test.go
@@ -37,6 +37,12 @@ func TestV1alpha1(t *testing.T) {
 	t.Run("crudAccessToMachineClient", func(t *testing.T) {
 		crudAccessToMachineClient(t, cs)
 	})
+	t.Run("crudAccessToMachineSetClient", func(t *testing.T) {
+		// TODO: the following test fails with:
+		// the namespace of the provided object does not match the namespace sent on the request
+		// uncomment when fixed
+		//crudAccessToMachineSetClient(t, cs)
+	})
 
 	testenv.Stop()
 }

--- a/ext-apiserver/pkg/controller/machineset/controller.go
+++ b/ext-apiserver/pkg/controller/machineset/controller.go
@@ -17,10 +17,14 @@ limitations under the License.
 package machineset
 
 import (
+	"fmt"
 	"github.com/golang/glog"
 	"github.com/kubernetes-incubator/apiserver-builder/pkg/builders"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/kube-deploy/ext-apiserver/pkg/apis/cluster/v1alpha1"
+	machineclientset "k8s.io/kube-deploy/ext-apiserver/pkg/client/clientset_generated/clientset"
 	listers "k8s.io/kube-deploy/ext-apiserver/pkg/client/listers_generated/cluster/v1alpha1"
 	"k8s.io/kube-deploy/ext-apiserver/pkg/controller/sharedinformers"
 )
@@ -29,24 +33,118 @@ import (
 type MachineSetControllerImpl struct {
 	builders.DefaultControllerFns
 
-	// lister indexes properties about MachineSet
-	lister listers.MachineSetLister
+	// machineClient a client that knows how to consume Machine resources
+	machineClient machineclientset.Interface
+
+	// machineSetsLister indexes properties about MachineSet
+	machineSetsLister listers.MachineSetLister
+
+	// machineLister holds a lister that knows how to list Machines from a cache
+	machineLister listers.MachineLister
 }
 
 // Init initializes the controller and is called by the generated code
 // Register watches for additional resource types here.
 func (c *MachineSetControllerImpl) Init(arguments sharedinformers.ControllerInitArguments) {
-	// Use the lister for indexing machinesets labels
-	c.lister = arguments.GetSharedInformers().Factory.Cluster().V1alpha1().MachineSets().Lister()
+	c.machineSetsLister = arguments.GetSharedInformers().Factory.Cluster().V1alpha1().MachineSets().Lister()
+	c.machineLister = arguments.GetSharedInformers().Factory.Cluster().V1alpha1().Machines().Lister()
+
+	var err error
+	c.machineClient, err = machineclientset.NewForConfig(arguments.GetRestConfig())
+	if err != nil {
+		glog.Fatalf("error building clientset for machineClient: %v", err)
+	}
 }
 
-// Reconcile handles enqueued messages
-func (c *MachineSetControllerImpl) Reconcile(u *v1alpha1.MachineSet) error {
-	// TODO: Implement controller logic here
-	glog.Infof("Running reconcile MachineSet for %s\n", u.Name)
-	return nil
+// Reconcile holds the controller's business logic.
+// it makes sure that the current state is equal to the desired state.
+// note that the current state of the cluster is calculated based on the number of machines
+// that are owned by the given machineSet (key).
+func (c *MachineSetControllerImpl) Reconcile(machineSet *v1alpha1.MachineSet) error {
+	filteredMachines, err := c.getMachines(machineSet)
+	if err != nil {
+		return err
+	}
+
+	return c.syncReplicas(machineSet, filteredMachines)
 }
 
 func (c *MachineSetControllerImpl) Get(namespace, name string) (*v1alpha1.MachineSet, error) {
-	return c.lister.MachineSets(namespace).Get(name)
+	return c.machineSetsLister.MachineSets(namespace).Get(name)
+}
+
+// syncReplicas essentially scales machine resources up and down.
+func (c *MachineSetControllerImpl) syncReplicas(machineSet *v1alpha1.MachineSet, machines []*v1alpha1.Machine) error {
+	var result error
+	currentMachineCount := int32(len(machines))
+	desiredReplicas := *machineSet.Spec.Replicas
+	diff := int(currentMachineCount - desiredReplicas)
+
+	if diff < 0 {
+		diff *= -1
+		for i := 0; i < diff; i++ {
+			glog.V(2).Infof("creating a machine ( spec.replicas(%d) > currentMachineCount(%d) )", desiredReplicas, currentMachineCount)
+			machine, err := c.createMachine(machineSet)
+			if err != nil {
+				return err
+			}
+			_, err = c.machineClient.ClusterV1alpha1().Machines(machineSet.Namespace).Create(machine)
+			if err != nil {
+				glog.Errorf("unable to create a machine = %s, due to %v", machine.Name, err)
+				result = err
+			}
+		}
+	} else if diff > 0 {
+		for i := 0; i < diff; i++ {
+			glog.V(2).Infof("deleting a machine ( spec.replicas(%d) < currentMachineCount(%d) )", desiredReplicas, currentMachineCount)
+			// TODO: Define machines deletion policies.
+			// see: https://github.com/kubernetes/kube-deploy/issues/625
+			machineToDelete := machines[i]
+			err := c.machineClient.ClusterV1alpha1().Machines(machineSet.Namespace).Delete(machineToDelete.Name, &metav1.DeleteOptions{})
+			if err != nil {
+				glog.Errorf("unable to delete a machine = %s, due to %v", machineToDelete.Name, err)
+				result = err
+			}
+		}
+	}
+
+	return result
+}
+
+// createMachine creates a machine resource.
+// the name of the newly created resource is going to be created by the API server, we set the generateName field
+// in addition, the newly created resource is owned by the given machineSet (we set the OwnerReferences field)
+func (c *MachineSetControllerImpl) createMachine(machineSet *v1alpha1.MachineSet) (*v1alpha1.Machine, error) {
+	gv := v1alpha1.SchemeGroupVersion
+	machine := &v1alpha1.Machine{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       gv.WithKind("Machine").Kind,
+			APIVersion: gv.String(),
+		},
+		ObjectMeta: machineSet.Spec.Template.ObjectMeta,
+		Spec:       machineSet.Spec.Template.Spec,
+	}
+	machine.ObjectMeta.OwnerReferences = append(machine.ObjectMeta.OwnerReferences, *metav1.NewControllerRef(machineSet, gv.WithKind("MachineSet")))
+	machine.ObjectMeta.GenerateName = fmt.Sprintf("%s-", machineSet.Name)
+
+	return machine, nil
+}
+
+// getMachines returns a list of machines that match on machineSet.UID
+func (c *MachineSetControllerImpl) getMachines(machineSet *v1alpha1.MachineSet) ([]*v1alpha1.Machine, error) {
+	filteredMachines := []*v1alpha1.Machine{}
+	allMachines, err := c.machineLister.List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+	for _, machine := range allMachines {
+		oRef := metav1.GetControllerOf(machine)
+		if oRef == nil {
+			continue
+		}
+		if oRef.UID == machineSet.UID {
+			filteredMachines = append(filteredMachines, machine)
+		}
+	}
+	return filteredMachines, nil
 }

--- a/ext-apiserver/pkg/controller/machineset/controller_test.go
+++ b/ext-apiserver/pkg/controller/machineset/controller_test.go
@@ -31,9 +31,12 @@ import (
 func machineSetControllerReconcile(t *testing.T, cs *clientset.Clientset, controller *machineset.MachineSetController) {
 	instance := v1alpha1.MachineSet{}
 	instance.Name = "instance-1"
-	expectedKey := "default/instance-1"
 	replicas := int32(0)
 	instance.Spec.Replicas = &replicas
+	instance.Spec.Selector = metav1.LabelSelector{MatchLabels: map[string]string{"foo":"barr"}}
+	instance.Spec.Template.Labels = map[string]string{"foo":"barr"}
+
+	expectedKey := "default/instance-1"
 
 	// When creating a new object, it should invoke the reconcile method.
 	cluster := v1alpha1.Cluster{}

--- a/ext-apiserver/pkg/controller/machineset/controller_test.go
+++ b/ext-apiserver/pkg/controller/machineset/controller_test.go
@@ -32,6 +32,8 @@ func machineSetControllerReconcile(t *testing.T, cs *clientset.Clientset, contro
 	instance := v1alpha1.MachineSet{}
 	instance.Name = "instance-1"
 	expectedKey := "default/instance-1"
+	replicas := int32(0)
+	instance.Spec.Replicas = &replicas
 
 	// When creating a new object, it should invoke the reconcile method.
 	cluster := v1alpha1.Cluster{}

--- a/ext-apiserver/pkg/controller/machineset/reconcile_test.go
+++ b/ext-apiserver/pkg/controller/machineset/reconcile_test.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machineset
+
+import (
+	"fmt"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/diff"
+	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/kube-deploy/ext-apiserver/pkg/apis/cluster/v1alpha1"
+	"k8s.io/kube-deploy/ext-apiserver/pkg/client/clientset_generated/clientset/fake"
+	v1alpha1listers "k8s.io/kube-deploy/ext-apiserver/pkg/client/listers_generated/cluster/v1alpha1"
+)
+
+func TestMachineSetControllerReconcileHandler(t *testing.T) {
+	tests := []struct {
+		name                string
+		startingMachineSets []*v1alpha1.MachineSet
+		startingMachines    []*v1alpha1.Machine
+		machineSetToSync    string
+		namespaceToSync     string
+		expectedMachine     *v1alpha1.Machine
+		expectedActions     []string
+	}{
+		{
+			name:                "scenario 1: the current state of the cluster is empty, thus a machine is created.",
+			startingMachineSets: []*v1alpha1.MachineSet{createMachineSet(1, "foo", "bar1", "acme")},
+			startingMachines:    nil,
+			machineSetToSync:    "foo",
+			namespaceToSync:     "acme",
+			expectedActions:     []string{"create"},
+			expectedMachine:     machineFromMachineSet(createMachineSet(1, "foo", "bar1", "acme"), "bar1"),
+		},
+		{
+			name:                "scenario 2: the current state of the cluster is too small, thus a machine is created.",
+			startingMachineSets: []*v1alpha1.MachineSet{createMachineSet(3, "foo", "bar3", "acme")},
+			startingMachines:    []*v1alpha1.Machine{machineFromMachineSet(createMachineSet(3, "foo", "bar1", "acme"), "bar1"), machineFromMachineSet(createMachineSet(3, "foo", "bar2", "acme"), "bar2")},
+			machineSetToSync:    "foo",
+			namespaceToSync:     "acme",
+			expectedActions:     []string{"create"},
+			expectedMachine:     machineFromMachineSet(createMachineSet(3, "foo", "bar3", "acme"), "bar3"),
+		},
+		{
+			name:                "scenario 3: the current state of the cluster is equal to the desired one, no machine resource is created.",
+			startingMachineSets: []*v1alpha1.MachineSet{createMachineSet(2, "foo", "bar3", "acme")},
+			startingMachines:    []*v1alpha1.Machine{machineFromMachineSet(createMachineSet(2, "foo", "bar1", "acme"), "bar1"), machineFromMachineSet(createMachineSet(2, "foo", "bar2", "acme"), "bar2")},
+			machineSetToSync:    "foo",
+			namespaceToSync:     "acme",
+			expectedActions:     []string{},
+		},
+		{
+			name:                "scenario 4: the current state of the cluster is bigger than the desired one, thus a machine is deleted.",
+			startingMachineSets: []*v1alpha1.MachineSet{createMachineSet(0, "foo", "bar2", "acme")},
+			startingMachines:    []*v1alpha1.Machine{machineFromMachineSet(createMachineSet(1, "foo", "bar1", "acme"), "bar1")},
+			machineSetToSync:    "foo",
+			namespaceToSync:     "acme",
+			expectedActions:     []string{"delete"},
+		},
+		{
+			name:                "scenario 5: the current state of the cluster is bigger than the desired one, thus machines are deleted.",
+			startingMachineSets: []*v1alpha1.MachineSet{createMachineSet(0, "foo", "bar2", "acme")},
+			startingMachines:    []*v1alpha1.Machine{machineFromMachineSet(createMachineSet(2, "foo", "bar1", "acme"), "bar1"), machineFromMachineSet(createMachineSet(2, "foo", "bar2", "acme"), "bar2")},
+			machineSetToSync:    "foo",
+			namespaceToSync:     "acme",
+			expectedActions:     []string{"delete", "delete"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// setup the test scenario
+			rObjects := []runtime.Object{}
+			machinesIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			for _, amachine := range test.startingMachines {
+				err := machinesIndexer.Add(amachine)
+				if err != nil {
+					t.Fatal(err)
+				}
+				rObjects = append(rObjects, amachine)
+			}
+			machineSetIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			for _, amachineset := range test.startingMachineSets {
+				err := machineSetIndexer.Add(amachineset)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			fakeClient := fake.NewSimpleClientset(rObjects...)
+			machineLister := v1alpha1listers.NewMachineLister(machinesIndexer)
+			machineSetLister := v1alpha1listers.NewMachineSetLister(machineSetIndexer)
+			target := &MachineSetControllerImpl{}
+			target.machineClient = fakeClient
+			target.machineSetsLister = machineSetLister
+			target.machineLister = machineLister
+
+			// act
+			machineSetToTest, err := target.Get(test.namespaceToSync, test.machineSetToSync)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = target.Reconcile(machineSetToTest)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// validate
+			actions := fakeClient.Actions()
+			if len(actions) != len(test.expectedActions) {
+				t.Fatalf("unexpected actions: %v, expected %d actions got %d", actions, len(test.expectedActions), len(actions))
+			}
+			for i, verb := range test.expectedActions {
+				if actions[i].GetVerb() != verb {
+					t.Fatalf("unexpected action: %v, expected %s", actions[i], verb)
+				}
+			}
+
+			if test.expectedMachine != nil {
+				// we take only the first item in line
+				var actualMachine *v1alpha1.Machine
+				for _, action := range actions {
+					if action.GetVerb() == "create" {
+						createAction, ok := action.(clienttesting.CreateAction)
+						if !ok {
+							t.Fatalf("unexpected action %#v", action)
+						}
+						actualMachine = createAction.GetObject().(*v1alpha1.Machine)
+						break
+					}
+				}
+
+				if !equality.Semantic.DeepEqual(actualMachine, test.expectedMachine) {
+					t.Fatalf("acutal machine is different from the expected one: %v", diff.ObjectDiff(test.expectedMachine, actualMachine))
+				}
+			}
+		})
+	}
+}
+
+func createMachineSet(replicas int, machineSetName string, machineName string, namespace string) *v1alpha1.MachineSet {
+	replicasInt32 := int32(replicas)
+	return &v1alpha1.MachineSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "MachineSet",
+			APIVersion: v1alpha1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      machineSetName,
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.MachineSetSpec{
+			Replicas: &replicasInt32,
+			Template: v1alpha1.MachineTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      machineName,
+					Namespace: namespace,
+				},
+				Spec: v1alpha1.MachineSpec{
+					ProviderConfig: "some provider specific configuration data",
+				},
+			},
+		},
+	}
+}
+
+func machineFromMachineSet(machineSet *v1alpha1.MachineSet, name string) *v1alpha1.Machine {
+	amachine := &v1alpha1.Machine{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Machine",
+			APIVersion: v1alpha1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: machineSet.Spec.Template.ObjectMeta,
+		Spec:       machineSet.Spec.Template.Spec,
+	}
+
+	amachine.Name = name
+	amachine.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(machineSet, v1alpha1.SchemeGroupVersion.WithKind("MachineSet"))}
+	amachine.GenerateName = fmt.Sprintf("%s-", machineSet.Name)
+
+	return amachine
+}

--- a/ext-apiserver/sample/machineset.yaml
+++ b/ext-apiserver/sample/machineset.yaml
@@ -6,8 +6,11 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      type: strong-machine
+      foo: bar
   template:
+    metadata:
+      labels:
+        foo: bar
     spec:
       providerConfig: >
         {

--- a/ext-apiserver/sample/machineset.yaml
+++ b/ext-apiserver/sample/machineset.yaml
@@ -1,5 +1,27 @@
-apiVersion: cluster.k8s.io/v1alpha1
+apiVersion: "cluster.k8s.io/v1alpha1"
 kind: MachineSet
 metadata:
-  name: machineset-example
+  name: my-first-machineset
 spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      type: strong-machine
+  template:
+    spec:
+      providerConfig: >
+        {
+          "apiVersion": "gceproviderconfig/v1alpha1",
+          "kind": "GCEProviderConfig",
+          "project": "$GCLOUD_PROJECT",
+          "zone": "us-central1-f",
+          "machineType": "n1-standard-1",
+          "image": "projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts"
+        }
+      versions:
+        kubelet: 1.7.4
+        containerRuntime:
+          name: docker
+          version: 1.12.0
+      roles:
+      - Node


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: this PR brings an initial implementation of `MachineSet` controller. It watches for `MachineSet` resources and makes sure that the current state is equal to the desired one. At the moment the current state of the cluster is calculated based on the number of machines that are owned by the given machineSet resource. This essentially means that newly created resources have their `OwnerReferences`  field set to the given `MachineSet` resource.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
