### PR TITLE
Convert ginko tests to standard testing framework

### DIFF
--- a/ext-apiserver/pkg/apis/cluster/v1alpha1/BUILD
+++ b/ext-apiserver/pkg/apis/cluster/v1alpha1/BUILD
@@ -40,8 +40,6 @@ go_test(
         "//pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1:go_default_library",
         "//pkg/openapi:go_default_library",
         "//vendor/github.com/kubernetes-incubator/apiserver-builder/pkg/test:go_default_library",
-        "//vendor/github.com/onsi/ginkgo:go_default_library",
-        "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
     ],

--- a/ext-apiserver/pkg/apis/cluster/v1alpha1/cluster_types_test.go
+++ b/ext-apiserver/pkg/apis/cluster/v1alpha1/cluster_types_test.go
@@ -1,4 +1,3 @@
-
 /*
 Copyright 2018 The Kubernetes Authors.
 
@@ -15,65 +14,74 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
 package v1alpha1_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"reflect"
+	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	. "k8s.io/kube-deploy/ext-apiserver/pkg/apis/cluster/v1alpha1"
-	. "k8s.io/kube-deploy/ext-apiserver/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1"
+	"k8s.io/kube-deploy/ext-apiserver/pkg/apis/cluster/v1alpha1"
+	"k8s.io/kube-deploy/ext-apiserver/pkg/client/clientset_generated/clientset"
 )
 
-var _ = Describe("Cluster", func() {
-	var instance Cluster
-	var expected Cluster
-	var client ClusterInterface
+func crudAccessToClusterClient(t *testing.T, cs *clientset.Clientset) {
+	instance := v1alpha1.Cluster{}
+	instance.Name = "instance-1"
 
-	BeforeEach(func() {
-		instance = Cluster{}
-		instance.Name = "instance-1"
+	expected := instance
 
-		expected = instance
-	})
+	// When sending a storage request for a valid config,
+	// it should provide CRUD access to the object.
+	client := cs.ClusterV1alpha1().Clusters("cluster-test-valid")
 
-	AfterEach(func() {
-		client.Delete(instance.Name, &metav1.DeleteOptions{})
-	})
+	// Test that the create request returns success.
+	actual, err := client.Create(&instance)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Delete(instance.Name, &metav1.DeleteOptions{})
+	if !reflect.DeepEqual(actual.Spec, expected.Spec) {
+		t.Fatalf(
+			"Default fields were not set correctly.\nActual:\t%+v\nExpected:\t%+v",
+			actual.Spec, expected.Spec)
+	}
 
-	Describe("when sending a storage request", func() {
-		Context("for a valid config", func() {
-			It("should provide CRUD access to the object", func() {
-				client = cs.ClusterV1alpha1().Clusters("cluster-test-valid")
+	// Test getting the created item for list requests.
+	result, err := client.List(metav1.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if itemLength := len(result.Items); itemLength != 1 {
+		t.Fatalf("Number of items in Items list should be 1, but is %d.", itemLength)
+	}
+	if resultSpec := result.Items[0].Spec; !reflect.DeepEqual(resultSpec, expected.Spec) {
+		t.Fatalf(
+			"Item returned from list is not equal to the expected item.\nActual:\t%+v\nExpected:\t%+v",
+			resultSpec, expected.Spec)
+	}
 
-				By("returning success from the create request")
-				actual, err := client.Create(&instance)
-				Expect(err).ShouldNot(HaveOccurred())
+	// Test getting the created item for get requests.
+	actual, err = client.Get(instance.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(actual.Spec, expected.Spec) {
+		t.Fatalf(
+			"Item returned from get is not equal to the expected item.\nActual:\t%+v\nExpected:\t%+v",
+			actual.Spec, expected.Spec)
+	}
 
-				By("defaulting the expected fields")
-				Expect(actual.Spec).To(Equal(expected.Spec))
-
-				By("returning the item for list requests")
-				result, err := client.List(metav1.ListOptions{})
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(result.Items).To(HaveLen(1))
-				Expect(result.Items[0].Spec).To(Equal(expected.Spec))
-
-				By("returning the item for get requests")
-				actual, err = client.Get(instance.Name, metav1.GetOptions{})
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(actual.Spec).To(Equal(expected.Spec))
-
-				By("deleting the item for delete requests")
-				err = client.Delete(instance.Name, &metav1.DeleteOptions{})
-				Expect(err).ShouldNot(HaveOccurred())
-				result, err = client.List(metav1.ListOptions{})
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(result.Items).To(HaveLen(0))
-			})
-		})
-	})
-})
+	// Test deleting the item for delete requests.
+	if deleteErr := client.Delete(instance.Name, &metav1.DeleteOptions{}); deleteErr != nil {
+		t.Fatal(deleteErr)
+	}
+	result, err = client.List(metav1.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if itemLength := len(result.Items); itemLength != 0 {
+		t.Fatalf("Number of items in Items list should be 0, but is %d.", itemLength)
+	}
+}

--- a/ext-apiserver/pkg/apis/cluster/v1alpha1/v1alpha1_suite_test.go
+++ b/ext-apiserver/pkg/apis/cluster/v1alpha1/v1alpha1_suite_test.go
@@ -1,4 +1,3 @@
-
 /*
 Copyright 2018 The Kubernetes Authors.
 
@@ -15,37 +14,29 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
 package v1alpha1_test
 
 import (
 	"testing"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"github.com/kubernetes-incubator/apiserver-builder/pkg/test"
-	"k8s.io/client-go/rest"
 
 	"k8s.io/kube-deploy/ext-apiserver/pkg/apis"
 	"k8s.io/kube-deploy/ext-apiserver/pkg/client/clientset_generated/clientset"
 	"k8s.io/kube-deploy/ext-apiserver/pkg/openapi"
 )
 
-var testenv *test.TestEnvironment
-var config *rest.Config
-var cs *clientset.Clientset
-
 func TestV1alpha1(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "v1 Suite", []Reporter{test.NewlineReporter{}})
-}
+	testenv := test.NewTestEnvironment()
+	config := testenv.Start(apis.GetAllApiBuilders(), openapi.GetOpenAPIDefinitions)
+	cs := clientset.NewForConfigOrDie(config)
 
-var _ = BeforeSuite(func() {
-	testenv = test.NewTestEnvironment()
-	config = testenv.Start(apis.GetAllApiBuilders(), openapi.GetOpenAPIDefinitions)
-	cs = clientset.NewForConfigOrDie(config)
-})
+	t.Run("crudAccessToClusterClient", func(t *testing.T) {
+		crudAccessToClusterClient(t, cs)
+	})
+	t.Run("crudAccessToMachineClient", func(t *testing.T) {
+		crudAccessToMachineClient(t, cs)
+	})
 
-var _ = AfterSuite(func() {
 	testenv.Stop()
-})
+}

--- a/ext-apiserver/pkg/controller/cluster/BUILD
+++ b/ext-apiserver/pkg/controller/cluster/BUILD
@@ -38,8 +38,6 @@ go_test(
         "//pkg/controller/sharedinformers:go_default_library",
         "//pkg/openapi:go_default_library",
         "//vendor/github.com/kubernetes-incubator/apiserver-builder/pkg/test:go_default_library",
-        "//vendor/github.com/onsi/ginkgo:go_default_library",
-        "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
     ],

--- a/ext-apiserver/pkg/controller/cluster/controller_test.go
+++ b/ext-apiserver/pkg/controller/cluster/controller_test.go
@@ -1,4 +1,3 @@
-
 /*
 Copyright 2018 The Kubernetes Authors.
 
@@ -15,77 +14,73 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
-package cluster_test
+package cluster
 
 import (
+	"testing"
 	"time"
 
-	. "k8s.io/kube-deploy/ext-apiserver/pkg/apis/cluster/v1alpha1"
-	. "k8s.io/kube-deploy/ext-apiserver/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/kube-deploy/ext-apiserver/pkg/apis/cluster/v1alpha1"
+	"k8s.io/kube-deploy/ext-apiserver/pkg/client/clientset_generated/clientset"
 )
 
-var _ = Describe("Cluster controller", func() {
-	var instance Cluster
-	var expectedKey string
-	var client ClusterInterface
-	var before chan struct{}
-	var after chan struct{}
+func clusterControllerReconcile(t *testing.T, cs *clientset.Clientset, controller *ClusterController) {
+	instance := v1alpha1.Cluster{}
+	instance.Name = "instance-1"
+	expectedKey := "cluster-controller-test-handler/instance-1"
 
-	BeforeEach(func() {
-		instance = Cluster{}
-		instance.Name = "instance-1"
-		expectedKey = "cluster-controller-test-handler/instance-1"
-	})
+	// When creating a new object, it should invoke the reconcile method.
+	client := cs.ClusterV1alpha1().Clusters("cluster-controller-test-handler")
+	before := make(chan struct{})
+	after := make(chan struct{})
 
-	AfterEach(func() {
-		client.Delete(instance.Name, &metav1.DeleteOptions{})
-	})
+	actualKey := ""
+	var actualErr error = nil
 
-	Describe("when creating a new object", func() {
-		It("invoke the reconcile method", func() {
-			client = cs.ClusterV1alpha1().Clusters("cluster-controller-test-handler")
-			before = make(chan struct{})
-			after = make(chan struct{})
+	// Setup test callbacks to be called when the message is reconciled
+	controller.BeforeReconcile = func(key string) {
+		defer close(before)
+		actualKey = key
+	}
+	controller.AfterReconcile = func(key string, err error) {
+		defer close(after)
+		actualKey = key
+		actualErr = err
+	}
 
-			actualKey := ""
-			var actualErr error = nil
+	// Create an instance
+	if _, err := client.Create(&instance); err != nil {
+		t.Fatal(err)
+	}
+	defer client.Delete(instance.Name, &metav1.DeleteOptions{})
+	// Verify reconcile function is called against the correct key
+	select {
+	case <-before:
+		if actualKey != expectedKey {
+			t.Fatalf(
+				"Reconcile function was not called with the correct key.\nActual:\t%+v\nExpected:\t%+v",
+				actualKey, expectedKey)
+		}
+		if actualErr != nil {
+			t.Fatal(actualErr)
+		}
+	case <-time.After(time.Second * 2):
+		t.Fatalf("reconcile never called")
+	}
 
-			// Setup test callbacks to be called when the message is reconciled
-			controller.BeforeReconcile = func(key string) {
-				defer close(before)
-				actualKey = key
-			}
-			controller.AfterReconcile = func(key string, err error) {
-				defer close(after)
-				actualKey = key
-				actualErr = err
-			}
-
-			// Create an instance
-			_, err := client.Create(&instance)
-			Expect(err).ShouldNot(HaveOccurred())
-
-			// Verify reconcile function is called against the correct key
-			select {
-			case <-before:
-				Expect(actualKey).To(Equal(expectedKey))
-				Expect(actualErr).ShouldNot(HaveOccurred())
-			case <-time.After(time.Second * 2):
-				Fail("reconcile never called")
-			}
-
-			select {
-			case <-after:
-				Expect(actualKey).To(Equal(expectedKey))
-				Expect(actualErr).ShouldNot(HaveOccurred())
-			case <-time.After(time.Second * 2):
-				Fail("reconcile never finished")
-			}
-		})
-	})
-})
+	select {
+	case <-after:
+		if actualKey != expectedKey {
+			t.Fatalf(
+				"Reconcile function was not called with the correct key.\nActual:\t%+v\nExpected:\t%+v",
+				actualKey, expectedKey)
+		}
+		if actualErr != nil {
+			t.Fatal(actualErr)
+		}
+	case <-time.After(time.Second * 2):
+		t.Fatalf("reconcile never finished")
+	}
+}

--- a/ext-apiserver/pkg/controller/machine/BUILD
+++ b/ext-apiserver/pkg/controller/machine/BUILD
@@ -38,8 +38,6 @@ go_test(
         "//pkg/controller/sharedinformers:go_default_library",
         "//pkg/openapi:go_default_library",
         "//vendor/github.com/kubernetes-incubator/apiserver-builder/pkg/test:go_default_library",
-        "//vendor/github.com/onsi/ginkgo:go_default_library",
-        "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
     ],

--- a/ext-apiserver/pkg/controller/machine/machine_suite_test.go
+++ b/ext-apiserver/pkg/controller/machine/machine_suite_test.go
@@ -14,49 +14,35 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package machine_test
+package machine
 
 import (
 	"testing"
 
 	"github.com/kubernetes-incubator/apiserver-builder/pkg/test"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"k8s.io/client-go/rest"
 
 	"k8s.io/kube-deploy/ext-apiserver/pkg/apis"
 	"k8s.io/kube-deploy/ext-apiserver/pkg/client/clientset_generated/clientset"
 	cfg "k8s.io/kube-deploy/ext-apiserver/pkg/controller/config"
-	"k8s.io/kube-deploy/ext-apiserver/pkg/controller/machine"
 	"k8s.io/kube-deploy/ext-apiserver/pkg/controller/sharedinformers"
 	"k8s.io/kube-deploy/ext-apiserver/pkg/openapi"
 )
 
-var testenv *test.TestEnvironment
-var config *rest.Config
-var cs *clientset.Clientset
-var shutdown chan struct{}
-var controller *machine.MachineController
-var si *sharedinformers.SharedInformers
-
 func TestMachine(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "Machine Suite", []Reporter{test.NewlineReporter{}})
-}
-
-var _ = BeforeSuite(func() {
-	testenv = test.NewTestEnvironment()
-	config = testenv.Start(apis.GetAllApiBuilders(), openapi.GetOpenAPIDefinitions)
-	cs = clientset.NewForConfigOrDie(config)
+	testenv := test.NewTestEnvironment()
+	config := testenv.Start(apis.GetAllApiBuilders(), openapi.GetOpenAPIDefinitions)
+	cs := clientset.NewForConfigOrDie(config)
 	cfg.ControllerConfig.Cloud = "test"
 
-	shutdown = make(chan struct{})
-	si = sharedinformers.NewSharedInformers(config, shutdown)
-	controller = machine.NewMachineController(config, si)
+	shutdown := make(chan struct{})
+	si := sharedinformers.NewSharedInformers(config, shutdown)
+	controller := NewMachineController(config, si)
 	controller.Run(shutdown)
-})
 
-var _ = AfterSuite(func() {
+	t.Run("machineControllerReconcile", func(t *testing.T) {
+		machineControllerReconcile(t, cs, controller)
+	})
+
 	close(shutdown)
 	testenv.Stop()
-})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR converts the three test suites using the Ginkgo and Gomega framework to use the standard Go testing framework.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #611

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
