### PR TITLE
Make OS image configurable

### DIFF
--- a/ext-apiserver/cloud/google/machineactuator.go
+++ b/ext-apiserver/cloud/google/machineactuator.go
@@ -673,7 +673,7 @@ func (gce *GCEClient) getImage(machine *clusterv1.Machine, config *gceconfig.GCE
 		// Only the image name was specified in config, so check if it is preloaded in the project specified in config.
 		fullPath := fmt.Sprintf("projects/%s/global/images/%s", project, img)
 		if _, err := gce.service.Images.Get(project, img).Do(); err == nil {
-			return fullPath, true
+			return fullPath, false
 		}
 
 		// Otherwise, fall back to the non-preloaded base image.
@@ -691,7 +691,7 @@ func (gce *GCEClient) getImage(machine *clusterv1.Machine, config *gceconfig.GCE
 	}
 
 	if err == nil {
-		return img, true
+		return img, false
 	}
 
 	// Otherwise, fall back to the non-preloaded base image.

--- a/ext-apiserver/cloud/google/machineactuator.go
+++ b/ext-apiserver/cloud/google/machineactuator.go
@@ -682,12 +682,12 @@ func (gce *GCEClient) getImage(machine *clusterv1.Machine, config *gceconfig.GCE
 	}
 
 	// Check to see if the image exists in the given path. The presence of "family" in the path dictates which API call we need to make.
-	project, family, imgName := matches[1], matches[2], matches[3]
+	project, family, name := matches[1], matches[2], matches[3]
 	var err error
 	if family == "" {
-		_, err = gce.service.Images.Get(project, imgName).Do()
+		_, err = gce.service.Images.Get(project, name).Do()
 	} else {
-		_, err = gce.service.Images.GetFromFamily(project, imgName).Do()
+		_, err = gce.service.Images.GetFromFamily(project, name).Do()
 	}
 
 	if err == nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR pulls the OS image from provider configs instead of always using a default image. I added logic to check if the specified image exists before defaulting to a base image.

I also changed the default to use a more recent version
(projects/ubuntu-os-cloud/global/images/family/ubuntu-1710).

**Which issue(s) this PR fixes**:
Fixes #587

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
