### PR TITLE
Rebase machines.yaml generation to ext-apiserver

### DIFF
--- a/ext-apiserver/.gitignore
+++ b/ext-apiserver/.gitignore
@@ -1,0 +1,2 @@
+gcp-deployer/gcp-deployer
+gcp-deployer/machines.yaml

--- a/ext-apiserver/gcp-deployer/generate-yaml.sh
+++ b/ext-apiserver/gcp-deployer/generate-yaml.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+set -e
+
+GCLOUD_PROJECT=$(gcloud config get-value project)
+
+TEMPLATE_FILE=machines.yaml.template
+GENERATED_FILE=machines.yaml
+OVERWRITE=0
+
+SCRIPT=$(basename $0)
+while test $# -gt 0; do
+        case "$1" in
+          -h|--help)
+            echo "$SCRIPT - generates input yaml files for Cluster API on Google Cloud Platform"
+            echo " "
+            echo "$SCRIPT [options]"
+            echo " "
+            echo "options:"
+            echo "-h, --help                show brief help"
+            echo "-f, --force-overwrite     if file to be generated already exists, force script to overwrite it"
+            exit 0
+            ;;
+          -f)
+            OVERWRITE=1
+            shift
+            ;;
+          --force-overwrite)
+            OVERWRITE=1
+            shift
+            ;;
+          *)
+            break
+            ;;
+        esac
+done
+
+if [ $OVERWRITE -ne 1 ] && [ -f $GENERATED_FILE ]; then
+  echo File $GENERATED_FILE already exists. Delete it manually before running this script.
+  exit 1
+fi
+
+sed -e "s/\$GCLOUD_PROJECT/$GCLOUD_PROJECT/" $TEMPLATE_FILE > $GENERATED_FILE

--- a/ext-apiserver/gcp-deployer/machines.yaml.template
+++ b/ext-apiserver/gcp-deployer/machines.yaml.template
@@ -10,14 +10,14 @@ items:
       {
         "apiVersion": "gceproviderconfig/v1alpha1",
         "kind": "GCEProviderConfig",
-        "project": "k8s-cluster-api",
+        "project": "$GCLOUD_PROJECT",
         "zone": "us-central1-f",
         "machineType": "n1-standard-2",
         "image": "projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts"
       }
     versions:
-      kubelet: 1.8.3
-      controlPlane: 1.8.3
+      kubelet: 1.7.4
+      controlPlane: 1.7.4
       containerRuntime:
         name: docker
         version: 1.12.0
@@ -34,13 +34,13 @@ items:
       {
         "apiVersion": "gceproviderconfig/v1alpha1",
         "kind": "GCEProviderConfig",
-        "project": "k8s-cluster-api",
+        "project": "$GCLOUD_PROJECT",
         "zone": "us-central1-f",
         "machineType": "n1-standard-1",
         "image": "projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts"
       }
     versions:
-      kubelet: 1.8.3
+      kubelet: 1.7.4
       containerRuntime:
         name: docker
         version: 1.12.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Rebase the machines.yaml generation and update the gitignore file in ext-apiserver.

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
