### PR TITLE
Only print error during bootstrap if err

### DIFF
--- a/ext-apiserver/gcp-deployer/deploy/deploy_helper.go
+++ b/ext-apiserver/gcp-deployer/deploy/deploy_helper.go
@@ -210,9 +210,12 @@ func (d *deployer) copyKubeConfig(master *clusterv1.Machine) error {
 	writeErr := util.Retry(func() (bool, error) {
 		glog.Infof("Waiting for Kubernetes to come up...")
 		config, err := d.machineDeployer.GetKubeConfig(master)
-		if err != nil || config == "" {
+		if err != nil {
 			glog.Errorf("Error while retriving kubeconfig %s", err)
 			return false, err
+		}
+		if config == "" {
+			return false, nil
 		}
 		glog.Infof("Kubernetes is up.. Writing kubeconfig to disk.")
 		err = d.writeConfigToDisk(config)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Currently the error statement gets logged even if err == nil. Not super helpful.

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
