### PR TITLE
Remove apimachinery/wait dep from deploy_helper

### DIFF
--- a/ext-apiserver/gcp-deployer/deploy/deploy_helper.go
+++ b/ext-apiserver/gcp-deployer/deploy/deploy_helper.go
@@ -26,7 +26,6 @@ import (
 	"github.com/golang/glog"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	clusterv1 "k8s.io/kube-deploy/ext-apiserver/pkg/apis/cluster/v1alpha1"
 	"k8s.io/kube-deploy/ext-apiserver/util"
@@ -118,7 +117,7 @@ func (d *deployer) createCluster(c *clusterv1.Cluster, machines []*clusterv1.Mac
 }
 
 func (d *deployer) waitForClusterResourceReady() error {
-	err := wait.Poll(500*time.Millisecond, 120*time.Second, func() (bool, error) {
+	err := util.Poll(500*time.Millisecond, 120*time.Second, func() (bool, error) {
 		_, err := d.clientSet.Discovery().ServerResourcesForGroupVersion("cluster.k8s.io/v1alpha1")
 		if err == nil {
 			return true, nil
@@ -165,7 +164,7 @@ func (d *deployer) delete(name string) error {
 	if err != nil {
 		return err
 	}
-	err = wait.Poll(500*time.Millisecond, 120*time.Second, func() (bool, error) {
+	err = util.Poll(500*time.Millisecond, 120*time.Second, func() (bool, error) {
 		if _, err = d.client.Machines(apiv1.NamespaceDefault).Get(name, metav1.GetOptions{}); err == nil {
 			return false, nil
 		}

--- a/ext-apiserver/util/retry.go
+++ b/ext-apiserver/util/retry.go
@@ -45,3 +45,7 @@ func Retry(fn wait.ConditionFunc, initialBackoffSec int) error {
 	}
 	return nil
 }
+
+func Poll(interval, timeout time.Duration, condition wait.ConditionFunc) error {
+	return wait.Poll(interval, timeout, condition)
+}


### PR DESCRIPTION
**What this PR does / why we need it**: 

**Which issue(s) this PR fixes**: Simple refactor to hide `wait.Poll` in the util package, and remove apimachinery/wait import from deploy_helper.
#562 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
