### PR TITLE
fixes logged error message in deploy_helper

### DIFF
--- a/cluster-api-gcp/deploy/deploy_helper.go
+++ b/cluster-api-gcp/deploy/deploy_helper.go
@@ -242,7 +242,13 @@ func (d *deployer) copyKubeConfig(master *clusterv1.Machine) error {
 		glog.Infof("Waiting for Kubernetes to come up...")
 		config, err := d.machineDeployer.GetKubeConfig(master)
 		if err != nil || config == "" {
-			glog.Errorf("Error while retriving kubeconfig %s", err)
+			var msg string
+			if err == nil {
+				msg = "configuration not available"
+			} else {
+				msg = err.Error()
+			}
+			glog.Errorf("Error while retrieving kubeconfig: %s", msg)
 			return false, err
 		}
 		glog.Infof("Kubernetes is up.. Writing kubeconfig to disk.")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

fixes logged error message when the error is nil and there is no configuration

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
