### PR TITLE
Updating owners aliases to reflect changes to sig leadership and the github teams

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,10 +2,10 @@
 
 aliases:
   sig-cluster-lifecycle-leads:
-    - jbeda
     - lukemarsden
     - luxas
     - roberthbailey
+    - timothysc
   kube-deploy-admins:
     - justinsb
     - krousey
@@ -13,6 +13,7 @@ aliases:
     - roberthbailey
   kube-deploy-maintainers:
     - jessicaochen
+    - karan
     - kris-nova
     - krousey
     - medinatiger


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
