### PR TITLE
Add Validation for cluster resource type in apiserver

### DIFF
--- a/cluster-api/cloud/google/machineactuator.go
+++ b/cluster-api/cloud/google/machineactuator.go
@@ -149,15 +149,6 @@ func (gce *GCEClient) Create(cluster *clusterv1.Cluster, machine *clusterv1.Mach
 	}
 
 	var metadata map[string]string
-	if cluster.Spec.ClusterNetwork.ServiceDomain == "" {
-		return errors.New("invalid cluster configuration: missing Cluster.Spec.ClusterNetwork.ServiceDomain")
-	}
-	if getSubnet(cluster.Spec.ClusterNetwork.Pods) == "" {
-		return errors.New("invalid cluster configuration: missing Cluster.Spec.ClusterNetwork.Pods")
-	}
-	if getSubnet(cluster.Spec.ClusterNetwork.Services) == "" {
-		return errors.New("invalid cluster configuration: missing Cluster.Spec.ClusterNetwork.Services")
-	}
 	if machine.Spec.Versions.Kubelet == "" {
 		return errors.New("invalid master configuration: missing Machine.Spec.Versions.Kubelet")
 	}

--- a/cluster-api/pkg/apis/cluster/v1alpha1/cluster_types.go
+++ b/cluster-api/pkg/apis/cluster/v1alpha1/cluster_types.go
@@ -113,6 +113,24 @@ func (ClusterStrategy) Validate(ctx request.Context, obj runtime.Object) field.E
 	log.Printf("Validating fields for Cluster %s\n", o.Name)
 	errors := field.ErrorList{}
 	// perform validation here and add to errors using field.Invalid
+	if o.Spec.ClusterNetwork.ServiceDomain == "" {
+		errors = append(errors, field.Invalid(
+			field.NewPath("Spec", "ClusterNetwork", "ServiceDomain"),
+			o.Spec.ClusterNetwork.ServiceDomain,
+			"invalid cluster configuration: missing Cluster.Spec.ClusterNetwork.ServiceDomain"))
+	}
+	if len(o.Spec.ClusterNetwork.Pods.CIDRBlocks) == 0 {
+		errors = append(errors, field.Invalid(
+			field.NewPath("Spec", "ClusterNetwork", "Pods"),
+			o.Spec.ClusterNetwork.Pods,
+			"invalid cluster configuration: missing Cluster.Spec.ClusterNetwork.Pods"))
+	}
+	if len(o.Spec.ClusterNetwork.Services.CIDRBlocks) == 0 {
+		errors = append(errors, field.Invalid(
+			field.NewPath("Spec", "ClusterNetwork", "Services"),
+			o.Spec.ClusterNetwork.Services,
+			"invalid cluster configuration: missing Cluster.Spec.ClusterNetwork.Services"))
+	}
 	return errors
 }
 

--- a/cluster-api/pkg/apis/cluster/v1alpha1/cluster_types_test.go
+++ b/cluster-api/pkg/apis/cluster/v1alpha1/cluster_types_test.go
@@ -23,23 +23,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/kube-deploy/cluster-api/pkg/apis/cluster/v1alpha1"
+	"k8s.io/kube-deploy/cluster-api/pkg/apis/cluster/v1alpha1/testutil"
 	"k8s.io/kube-deploy/cluster-api/pkg/client/clientset_generated/clientset"
 )
 
 func crudAccessToClusterClient(t *testing.T, cs *clientset.Clientset) {
-	instance := v1alpha1.Cluster{
-		Spec: v1alpha1.ClusterSpec{
-			ClusterNetwork: v1alpha1.ClusterNetworkingConfig{
-				Services: v1alpha1.NetworkRanges{
-					CIDRBlocks: []string{"10.96.0.0/12"},
-				},
-				Pods: v1alpha1.NetworkRanges{
-					CIDRBlocks: []string{"192.168.0.0/16"},
-				},
-				ServiceDomain: "cluster.local",
-			},
-		},
-	}
+	instance := testutil.GetVanillaCluster()
 	instance.Name = "instance-1"
 
 	expected := instance

--- a/cluster-api/pkg/apis/cluster/v1alpha1/cluster_types_test.go
+++ b/cluster-api/pkg/apis/cluster/v1alpha1/cluster_types_test.go
@@ -137,6 +137,23 @@ func clusterValidationTest(t *testing.T, cs *clientset.Clientset) {
 			},
 			errExpected: true,
 		},
+		{
+			name: "positive test case",
+			cluster: v1alpha1.Cluster{
+				Spec: v1alpha1.ClusterSpec{
+					ClusterNetwork: v1alpha1.ClusterNetworkingConfig{
+						Services: v1alpha1.NetworkRanges{
+							CIDRBlocks: []string{"10.96.0.0/12"},
+						},
+						Pods: v1alpha1.NetworkRanges{
+							CIDRBlocks: []string{"192.168.0.0/16"},
+						},
+						ServiceDomain: "cluster.local",
+					},
+				},
+			},
+			errExpected: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cluster-api/pkg/apis/cluster/v1alpha1/machine_types.go
+++ b/cluster-api/pkg/apis/cluster/v1alpha1/machine_types.go
@@ -184,8 +184,8 @@ type ContainerRuntimeInfo struct {
 
 // Validate checks that an instance of Machine is well formed
 func (MachineStrategy) Validate(ctx request.Context, obj runtime.Object) field.ErrorList {
-	o := obj.(*cluster.Machine)
-	log.Printf("Validating fields for Machine %s\n", o.Name)
+	machine := obj.(*cluster.Machine)
+	log.Printf("Validating fields for Machine %s\n", machine.Name)
 	errors := field.ErrorList{}
 	// perform validation here and add to errors using field.Invalid
 	return errors

--- a/cluster-api/pkg/apis/cluster/v1alpha1/testutil/testutil.go
+++ b/cluster-api/pkg/apis/cluster/v1alpha1/testutil/testutil.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testutil
+
+import "k8s.io/kube-deploy/cluster-api/pkg/apis/cluster/v1alpha1"
+
+// GetVanillaCluster return a bare minimum functional cluster resource object
+func GetVanillaCluster() v1alpha1.Cluster {
+	return v1alpha1.Cluster{
+		Spec: v1alpha1.ClusterSpec{
+			ClusterNetwork: v1alpha1.ClusterNetworkingConfig{
+				Services: v1alpha1.NetworkRanges{
+					CIDRBlocks: []string{"10.96.0.0/12"},
+				},
+				Pods: v1alpha1.NetworkRanges{
+					CIDRBlocks: []string{"192.168.0.0/16"},
+				},
+				ServiceDomain: "cluster.local",
+			},
+		},
+	}
+}

--- a/cluster-api/pkg/apis/cluster/v1alpha1/v1alpha1_suite_test.go
+++ b/cluster-api/pkg/apis/cluster/v1alpha1/v1alpha1_suite_test.go
@@ -34,6 +34,9 @@ func TestV1alpha1(t *testing.T) {
 	t.Run("crudAccessToClusterClient", func(t *testing.T) {
 		crudAccessToClusterClient(t, cs)
 	})
+	t.Run("clusterValidationTest", func(t *testing.T) {
+		clusterValidationTest(t, cs)
+	})
 	t.Run("crudAccessToMachineClient", func(t *testing.T) {
 		crudAccessToMachineClient(t, cs)
 	})

--- a/cluster-api/pkg/controller/cluster/controller_test.go
+++ b/cluster-api/pkg/controller/cluster/controller_test.go
@@ -22,24 +22,12 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/kube-deploy/cluster-api/pkg/apis/cluster/v1alpha1"
+	"k8s.io/kube-deploy/cluster-api/pkg/apis/cluster/v1alpha1/testutil"
 	"k8s.io/kube-deploy/cluster-api/pkg/client/clientset_generated/clientset"
 )
 
 func clusterControllerReconcile(t *testing.T, cs *clientset.Clientset, controller *ClusterController) {
-	instance := v1alpha1.Cluster{
-		Spec: v1alpha1.ClusterSpec{
-			ClusterNetwork: v1alpha1.ClusterNetworkingConfig{
-				Services: v1alpha1.NetworkRanges{
-					CIDRBlocks: []string{"10.96.0.0/12"},
-				},
-				Pods: v1alpha1.NetworkRanges{
-					CIDRBlocks: []string{"192.168.0.0/16"},
-				},
-				ServiceDomain: "cluster.local",
-			},
-		},
-	}
+	instance := testutil.GetVanillaCluster()
 	instance.Name = "instance-1"
 	expectedKey := "cluster-controller-test-handler/instance-1"
 

--- a/cluster-api/pkg/controller/cluster/controller_test.go
+++ b/cluster-api/pkg/controller/cluster/controller_test.go
@@ -27,7 +27,19 @@ import (
 )
 
 func clusterControllerReconcile(t *testing.T, cs *clientset.Clientset, controller *ClusterController) {
-	instance := v1alpha1.Cluster{}
+	instance := v1alpha1.Cluster{
+		Spec: v1alpha1.ClusterSpec{
+			ClusterNetwork: v1alpha1.ClusterNetworkingConfig{
+				Services: v1alpha1.NetworkRanges{
+					CIDRBlocks: []string{"10.96.0.0/12"},
+				},
+				Pods: v1alpha1.NetworkRanges{
+					CIDRBlocks: []string{"192.168.0.0/16"},
+				},
+				ServiceDomain: "cluster.local",
+			},
+		},
+	}
 	instance.Name = "instance-1"
 	expectedKey := "cluster-controller-test-handler/instance-1"
 

--- a/cluster-api/pkg/controller/machine/controller_test.go
+++ b/cluster-api/pkg/controller/machine/controller_test.go
@@ -33,7 +33,19 @@ func machineControllerReconcile(t *testing.T, cs *clientset.Clientset, controlle
 	expectedKey := "default/instance-1"
 
 	// When creating a new object, it should invoke the reconcile method.
-	cluster := v1alpha1.Cluster{}
+	cluster := v1alpha1.Cluster{
+		Spec: v1alpha1.ClusterSpec{
+			ClusterNetwork: v1alpha1.ClusterNetworkingConfig{
+				Services: v1alpha1.NetworkRanges{
+					CIDRBlocks: []string{"10.96.0.0/12"},
+				},
+				Pods: v1alpha1.NetworkRanges{
+					CIDRBlocks: []string{"192.168.0.0/16"},
+				},
+				ServiceDomain: "cluster.local",
+			},
+		},
+	}
 	cluster.Name = "cluster-1"
 	if _, err := cs.ClusterV1alpha1().Clusters("default").Create(&cluster); err != nil {
 		t.Fatal(err)

--- a/cluster-api/pkg/controller/machine/controller_test.go
+++ b/cluster-api/pkg/controller/machine/controller_test.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/kube-deploy/cluster-api/pkg/apis/cluster/v1alpha1"
+	"k8s.io/kube-deploy/cluster-api/pkg/apis/cluster/v1alpha1/testutil"
 	"k8s.io/kube-deploy/cluster-api/pkg/client/clientset_generated/clientset"
 )
 
@@ -33,19 +34,7 @@ func machineControllerReconcile(t *testing.T, cs *clientset.Clientset, controlle
 	expectedKey := "default/instance-1"
 
 	// When creating a new object, it should invoke the reconcile method.
-	cluster := v1alpha1.Cluster{
-		Spec: v1alpha1.ClusterSpec{
-			ClusterNetwork: v1alpha1.ClusterNetworkingConfig{
-				Services: v1alpha1.NetworkRanges{
-					CIDRBlocks: []string{"10.96.0.0/12"},
-				},
-				Pods: v1alpha1.NetworkRanges{
-					CIDRBlocks: []string{"192.168.0.0/16"},
-				},
-				ServiceDomain: "cluster.local",
-			},
-		},
-	}
+	cluster := testutil.GetVanillaCluster()
 	cluster.Name = "cluster-1"
 	if _, err := cs.ClusterV1alpha1().Clusters("default").Create(&cluster); err != nil {
 		t.Fatal(err)

--- a/cluster-api/pkg/controller/machineset/controller_test.go
+++ b/cluster-api/pkg/controller/machineset/controller_test.go
@@ -33,13 +33,25 @@ func machineSetControllerReconcile(t *testing.T, cs *clientset.Clientset, contro
 	instance.Name = "instance-1"
 	replicas := int32(0)
 	instance.Spec.Replicas = &replicas
-	instance.Spec.Selector = metav1.LabelSelector{MatchLabels: map[string]string{"foo":"barr"}}
-	instance.Spec.Template.Labels = map[string]string{"foo":"barr"}
+	instance.Spec.Selector = metav1.LabelSelector{MatchLabels: map[string]string{"foo": "barr"}}
+	instance.Spec.Template.Labels = map[string]string{"foo": "barr"}
 
 	expectedKey := "default/instance-1"
 
 	// When creating a new object, it should invoke the reconcile method.
-	cluster := v1alpha1.Cluster{}
+	cluster := v1alpha1.Cluster{
+		Spec: v1alpha1.ClusterSpec{
+			ClusterNetwork: v1alpha1.ClusterNetworkingConfig{
+				Services: v1alpha1.NetworkRanges{
+					CIDRBlocks: []string{"10.96.0.0/12"},
+				},
+				Pods: v1alpha1.NetworkRanges{
+					CIDRBlocks: []string{"192.168.0.0/16"},
+				},
+				ServiceDomain: "cluster.local",
+			},
+		},
+	}
 	cluster.Name = "cluster-1"
 	if _, err := cs.ClusterV1alpha1().Clusters("default").Create(&cluster); err != nil {
 		t.Fatal(err)

--- a/cluster-api/pkg/controller/machineset/controller_test.go
+++ b/cluster-api/pkg/controller/machineset/controller_test.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/kube-deploy/cluster-api/pkg/apis/cluster/v1alpha1"
+	"k8s.io/kube-deploy/cluster-api/pkg/apis/cluster/v1alpha1/testutil"
 	"k8s.io/kube-deploy/cluster-api/pkg/client/clientset_generated/clientset"
 	"k8s.io/kube-deploy/cluster-api/pkg/controller/machineset"
 )
@@ -39,19 +40,7 @@ func machineSetControllerReconcile(t *testing.T, cs *clientset.Clientset, contro
 	expectedKey := "default/instance-1"
 
 	// When creating a new object, it should invoke the reconcile method.
-	cluster := v1alpha1.Cluster{
-		Spec: v1alpha1.ClusterSpec{
-			ClusterNetwork: v1alpha1.ClusterNetworkingConfig{
-				Services: v1alpha1.NetworkRanges{
-					CIDRBlocks: []string{"10.96.0.0/12"},
-				},
-				Pods: v1alpha1.NetworkRanges{
-					CIDRBlocks: []string{"192.168.0.0/16"},
-				},
-				ServiceDomain: "cluster.local",
-			},
-		},
-	}
+	cluster := testutil.GetVanillaCluster()
 	cluster.Name = "cluster-1"
 	if _, err := cs.ClusterV1alpha1().Clusters("default").Create(&cluster); err != nil {
 		t.Fatal(err)

--- a/cluster-api/util/util.go
+++ b/cluster-api/util/util.go
@@ -28,9 +28,9 @@ import (
 	"github.com/golang/glog"
 
 	"k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	clustercommon "k8s.io/kube-deploy/cluster-api/pkg/apis/cluster/common"
 	clusterv1 "k8s.io/kube-deploy/cluster-api/pkg/apis/cluster/v1alpha1"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR add validation for cluster resource inside API Server. So, invalid resource creation will be rejected. In old CRD code, we did the validation in controller instead.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
