### PR TITLE
Update the machine controller image to pick up #644

### DIFF
--- a/ext-apiserver/cloud/google/pods.go
+++ b/ext-apiserver/cloud/google/pods.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/kube-deploy/ext-apiserver/cloud/google/config"
 )
 
-var machineControllerImage = "gcr.io/k8s-cluster-api/apiserver-controller:0.1"
+var machineControllerImage = "gcr.io/k8s-cluster-api/apiserver-controller:0.2"
 
 func init() {
 	if img, ok := os.LookupEnv("MACHINE_CONTROLLER_IMAGE"); ok {


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes: clusters started on GCP would be unable to create nodes using the machine controller.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
