### PR TITLE
Add owner reference for machines created via machineset controller

### DIFF
--- a/cluster-api/pkg/controller/machineset/controller.go
+++ b/cluster-api/pkg/controller/machineset/controller.go
@@ -123,6 +123,7 @@ func (c *MachineSetControllerImpl) createMachine(machineSet *v1alpha1.MachineSet
 		Spec:       machineSet.Spec.Template.Spec,
 	}
 	machine.ObjectMeta.GenerateName = fmt.Sprintf("%s-", machineSet.Name)
+	controller := true
 	blockOwnerDeletion := true
 	machine.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
 		{
@@ -130,6 +131,7 @@ func (c *MachineSetControllerImpl) createMachine(machineSet *v1alpha1.MachineSet
 			Name: machineSet.ObjectMeta.GetName(),
 			UID: machineSet.ObjectMeta.GetUID(),
 			APIVersion: v1alpha1.SchemeGroupVersion.String(),
+			Controller: &controller,
 			BlockOwnerDeletion: &blockOwnerDeletion,
 		},
 	}

--- a/cluster-api/pkg/controller/machineset/controller.go
+++ b/cluster-api/pkg/controller/machineset/controller.go
@@ -123,6 +123,16 @@ func (c *MachineSetControllerImpl) createMachine(machineSet *v1alpha1.MachineSet
 		Spec:       machineSet.Spec.Template.Spec,
 	}
 	machine.ObjectMeta.GenerateName = fmt.Sprintf("%s-", machineSet.Name)
+	blockOwnerDeletion := true
+	machine.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
+		{
+			Kind: "MachineSet",
+			Name: machineSet.ObjectMeta.GetName(),
+			UID: machineSet.ObjectMeta.GetUID(),
+			APIVersion: v1alpha1.SchemeGroupVersion.String(),
+			BlockOwnerDeletion: &blockOwnerDeletion,
+		},
+	}
 
 	return machine, nil
 }

--- a/cluster-api/pkg/controller/machineset/controller.go
+++ b/cluster-api/pkg/controller/machineset/controller.go
@@ -21,7 +21,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/kubernetes-incubator/apiserver-builder/pkg/builders"
 
-	"k8s.io/apimachinery/pkg/labels"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-deploy/cluster-api/pkg/apis/cluster/v1alpha1"
 	machineclientset "k8s.io/kube-deploy/cluster-api/pkg/client/clientset_generated/clientset"

--- a/cluster-api/pkg/controller/machineset/reconcile_test.go
+++ b/cluster-api/pkg/controller/machineset/reconcile_test.go
@@ -207,6 +207,7 @@ func machineFromMachineSet(machineSet *v1alpha1.MachineSet, name string) *v1alph
 
 	amachine.Name = name
 	amachine.GenerateName = fmt.Sprintf("%s-", machineSet.Name)
+	controller := true
 	blockOwnerDeletion := true
 	amachine.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
 		{
@@ -214,6 +215,7 @@ func machineFromMachineSet(machineSet *v1alpha1.MachineSet, name string) *v1alph
 			Name: machineSet.ObjectMeta.GetName(),
 			UID: machineSet.ObjectMeta.GetUID(),
 			APIVersion: v1alpha1.SchemeGroupVersion.String(),
+			Controller: &controller,
 			BlockOwnerDeletion: &blockOwnerDeletion,
 		},
 	}

--- a/cluster-api/pkg/controller/machineset/reconcile_test.go
+++ b/cluster-api/pkg/controller/machineset/reconcile_test.go
@@ -207,6 +207,16 @@ func machineFromMachineSet(machineSet *v1alpha1.MachineSet, name string) *v1alph
 
 	amachine.Name = name
 	amachine.GenerateName = fmt.Sprintf("%s-", machineSet.Name)
+	blockOwnerDeletion := true
+	amachine.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
+		{
+			Kind: "MachineSet",
+			Name: machineSet.ObjectMeta.GetName(),
+			UID: machineSet.ObjectMeta.GetUID(),
+			APIVersion: v1alpha1.SchemeGroupVersion.String(),
+			BlockOwnerDeletion: &blockOwnerDeletion,
+		},
+	}
 
 	return amachine
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds owner reference to machine objects created through the machineset controller. This allows garbage collection and cascading deletion to work.
Deleting the machineset will trigger the corresponding machines to be deleted.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
@kubernetes/kube-deploy-reviewers
