### PR TITLE
Add make rules for correcting permissions on GCR public images

### DIFF
--- a/cluster-api/cloud/google/cmd/gce-machine-controller/Makefile
+++ b/cluster-api/cloud/google/cmd/gce-machine-controller/Makefile
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-.PHONY: image push dev_image dev_push
+.PHONY: image push dev_image dev_push fix_gcs_permissions
 
-PREFIX = gcr.io/k8s-cluster-api
+GCR_BUCKET = k8s-cluster-api
+PREFIX = gcr.io/$(GCR_BUCKET)
 DEV_PREFIX ?= gcr.io/$(shell gcloud config get-value project)
 NAME = gce-machine-controller
 TAG = 0.0.1
@@ -24,6 +25,11 @@ image:
 
 push: image
 	docker push "$(PREFIX)/$(NAME):$(TAG)"
+	$(MAKE) fix_gcs_permissions
+
+fix_gcs_permissions:
+	gsutil acl ch -u AllUsers:READ gs://artifacts.$(GCR_BUCKET).appspot.com
+	gsutil -m acl ch -r -u AllUsers:READ gs://artifacts.$(GCR_BUCKET).appspot.com
 
 dev_image: 
 	docker build -t "$(DEV_PREFIX)/$(NAME):$(TAG)-dev" -f ./Dockerfile ../../../..

--- a/cluster-api/cmd/apiserver/Makefile
+++ b/cluster-api/cmd/apiserver/Makefile
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-.PHONY: image push dev_image dev_push
+.PHONY: image push dev_image dev_push fix_gcs_permissions
 
-PREFIX = gcr.io/k8s-cluster-api
+GCR_BUCKET = k8s-cluster-api
+PREFIX = gcr.io/$(GCR_BUCKET)
 DEV_PREFIX ?= gcr.io/$(shell gcloud config get-value project)
 NAME = cluster-apiserver
 TAG = 0.0.1
@@ -24,6 +25,11 @@ image:
 
 push: image
 	docker push "$(PREFIX)/$(NAME):$(TAG)"
+	$(MAKE) fix_gcs_permissions
+
+fix_gcs_permissions:
+	gsutil acl ch -u AllUsers:READ gs://artifacts.$(GCR_BUCKET).appspot.com
+	gsutil -m acl ch -r -u AllUsers:READ gs://artifacts.$(GCR_BUCKET).appspot.com
 
 dev_image: 
 	docker build -t "$(DEV_PREFIX)/$(NAME):$(TAG)-dev" -f ./Dockerfile ../..

--- a/cluster-api/cmd/controller-manager/Makefile
+++ b/cluster-api/cmd/controller-manager/Makefile
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-.PHONY: image push dev_image dev_push
+.PHONY: image push dev_image dev_push fix_gcs_permissions
 
-PREFIX = gcr.io/k8s-cluster-api
+GCR_BUCKET = k8s-cluster-api
+PREFIX = gcr.io/$(GCR_BUCKET)
 DEV_PREFIX ?= gcr.io/$(shell gcloud config get-value project)
 NAME = controller-manager
 TAG = 0.0.1
@@ -24,6 +25,11 @@ image:
 
 push: image
 	docker push "$(PREFIX)/$(NAME):$(TAG)"
+	$(MAKE) fix_gcs_permissions
+
+fix_gcs_permissions:
+	gsutil acl ch -u AllUsers:READ gs://artifacts.$(GCR_BUCKET).appspot.com
+	gsutil -m acl ch -r -u AllUsers:READ gs://artifacts.$(GCR_BUCKET).appspot.com
 
 dev_image: 
 	docker build -t "$(DEV_PREFIX)/$(NAME):$(TAG)-dev" -f ./Dockerfile ../..


### PR DESCRIPTION
**What this PR does / why we need it**: So everyone can read the images we publish.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Someone complained in the channel that the images weren't readable. This ensures that every time a new image is pushed, we make sure it's readable.

@kubernetes/kube-deploy-reviewers

cc @jessicaochen @medinatiger 