### PR TITLE
Remove machine finalizer if underlying instance does not exist

### DIFF
--- a/cluster-api/cloud/google/machineactuator.go
+++ b/cluster-api/cloud/google/machineactuator.go
@@ -285,10 +285,7 @@ func (gce *GCEClient) Delete(machine *clusterv1.Machine) error {
 
 	if instance == nil {
 		glog.Infof("Skipped deleting a VM that is already deleted.\n")
-		// Remove the finalizer
-		machine.ObjectMeta.Finalizers = util.Filter(machine.ObjectMeta.Finalizers, clusterv1.MachineFinalizer)
-		_, err = gce.machineClient.Update(machine)
-		return err
+		return nil
 	}
 
 	config, err := gce.providerconfig(machine.Spec.ProviderConfig)

--- a/cluster-api/cloud/google/machineactuator.go
+++ b/cluster-api/cloud/google/machineactuator.go
@@ -285,7 +285,10 @@ func (gce *GCEClient) Delete(machine *clusterv1.Machine) error {
 
 	if instance == nil {
 		glog.Infof("Skipped deleting a VM that is already deleted.\n")
-		return nil
+		// Remove the finalizer
+		machine.ObjectMeta.Finalizers = util.Filter(machine.ObjectMeta.Finalizers, clusterv1.MachineFinalizer)
+		_, err = gce.machineClient.Update(machine)
+		return err
 	}
 
 	config, err := gce.providerconfig(machine.Spec.ProviderConfig)

--- a/cluster-api/pkg/controller/machine/controller.go
+++ b/cluster-api/pkg/controller/machine/controller.go
@@ -45,7 +45,7 @@ type MachineControllerImpl struct {
 	actuator Actuator
 
 	kubernetesClientSet *kubernetes.Clientset
-	clientSet           *clientset.Clientset
+	clientSet           clientset.Interface
 	machineClient       v1alpha1.MachineInterface
 	linkedNodes         map[string]bool
 }
@@ -79,37 +79,46 @@ func (c *MachineControllerImpl) Init(arguments sharedinformers.ControllerInitArg
 // Reconcile handles enqueued messages. The delete will be handled by finalizer.
 func (c *MachineControllerImpl) Reconcile(machine *clusterv1.Machine) error {
 	// Implement controller logic here
-	glog.Infof("Running reconcile Machine for %s\n", machine.Name)
-	exist, err := c.actuator.Exists(machine)
-	if err == nil {
-		if !exist {
-			// Machine resource created. Machine does not yet exist.
-			glog.Infof("reconciling machine object %v triggers idempotent create.", machine.ObjectMeta.Name)
-			err = c.create(machine)
-		} else {
+	name := machine.Name
+	glog.Infof("Running reconcile Machine for %s\n", name)
+	isDeleting := !machine.ObjectMeta.DeletionTimestamp.IsZero()
+	hasMachineFinalizer := util.Contains(machine.ObjectMeta.Finalizers, clusterv1.MachineFinalizer)
 
-			if !machine.ObjectMeta.DeletionTimestamp.IsZero() {
-				// no-op if finalizer has been removed.
-				if !util.Contains(machine.ObjectMeta.Finalizers, clusterv1.MachineFinalizer) {
-					glog.Infof("reconciling machine object %v causes a no-op as there is no finalizer.", machine.ObjectMeta.Name)
-					return nil
-				}
-				if cfg.ControllerConfig.InCluster && util.IsMaster(machine) {
-					glog.Infof("skipping reconciling master machine object %v", machine.ObjectMeta.Name)
-				} else {
-					glog.Infof("reconciling machine object %v triggers delete.", machine.ObjectMeta.Name)
-					err = c.delete(machine)
-				}
-			} else {
-				glog.Infof("reconciling machine object %v triggers idempotent update.", machine.ObjectMeta.Name)
-				err = c.update(machine)
-			}
+	if isDeleting {
+		// no-op if finalizer has been removed.
+		if !hasMachineFinalizer {
+			glog.Infof("reconciling machine object %v causes a no-op as there is no finalizer.", name)
+			return nil
 		}
+		if cfg.ControllerConfig.InCluster && util.IsMaster(machine) {
+			glog.Infof("skipping reconciling master machine object %v", name)
+			return nil
+		}
+		glog.Infof("reconciling machine object %v triggers delete.", name)
+		if err := c.delete(machine); err != nil {
+			return err
+		}
+		// Remove finalizer on successful deletion.
+		glog.Infof("machine object %v deletion successful, removing finalizer.", name)
+		machine.ObjectMeta.Finalizers = util.Filter(machine.ObjectMeta.Finalizers, clusterv1.MachineFinalizer)
+		if _, err := c.machineClient.Update(machine); err != nil {
+			return err
+		}
+		return nil
 	}
+
+	exist, err := c.actuator.Exists(machine)
 	if err != nil {
 		glog.Errorf("reconciling failed with err: %v", err)
+		return err
 	}
-	return err
+	if exist {
+		glog.Infof("reconciling machine object %v triggers idempotent update.", name)
+		return c.update(machine)
+	}
+	// Machine resource created. Machine does not yet exist.
+	glog.Infof("reconciling machine object %v triggers idempotent create.", machine.ObjectMeta.Name)
+	return c.create(machine)
 }
 
 func (c *MachineControllerImpl) Get(namespace, name string) (*clusterv1.Machine, error) {

--- a/cluster-api/pkg/controller/machine/reconcile_test.go
+++ b/cluster-api/pkg/controller/machine/reconcile_test.go
@@ -17,28 +17,15 @@ limitations under the License.
 package machine
 
 import (
-	// "fmt"
 	"testing"
 	"time"
-	//"github.com/golang/glog"
 
-	//"github.com/kubernetes-incubator/apiserver-builder/pkg/test"
-	//"k8s.io/kube-deploy/cluster-api/pkg/apis"
-	//"k8s.io/kube-deploy/cluster-api/pkg/controller/sharedinformers"
-	//"k8s.io/kube-deploy/cluster-api/pkg/openapi"
-
-	//"k8s.io/kube-deploy/cluster-api/pkg/client/clientset_generated/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	// "k8s.io/apimachinery/pkg/api/equality"
-	// "k8s.io/apimachinery/pkg/util/diff"
-	// clienttesting "k8s.io/client-go/testing"
-	// "k8s.io/client-go/tools/cache"
+	clustercommon "k8s.io/kube-deploy/cluster-api/pkg/apis/cluster/common"
 	"k8s.io/kube-deploy/cluster-api/pkg/apis/cluster/v1alpha1"
 	"k8s.io/kube-deploy/cluster-api/pkg/apis/cluster/v1alpha1/testutil"
 	"k8s.io/kube-deploy/cluster-api/pkg/client/clientset_generated/clientset/fake"
-	clustercommon "k8s.io/kube-deploy/cluster-api/pkg/apis/cluster/common"
-	// v1alpha1listers "k8s.io/kube-deploy/cluster-api/pkg/client/listers_generated/cluster/v1alpha1"
 )
 
 type CountActuator struct{

--- a/cluster-api/pkg/controller/machine/reconcile_test.go
+++ b/cluster-api/pkg/controller/machine/reconcile_test.go
@@ -1,0 +1,208 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machine
+
+import (
+	// "fmt"
+	"testing"
+	"time"
+	//"github.com/golang/glog"
+
+	//"github.com/kubernetes-incubator/apiserver-builder/pkg/test"
+	//"k8s.io/kube-deploy/cluster-api/pkg/apis"
+	//"k8s.io/kube-deploy/cluster-api/pkg/controller/sharedinformers"
+	//"k8s.io/kube-deploy/cluster-api/pkg/openapi"
+
+	//"k8s.io/kube-deploy/cluster-api/pkg/client/clientset_generated/clientset"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	// "k8s.io/apimachinery/pkg/api/equality"
+	// "k8s.io/apimachinery/pkg/util/diff"
+	// clienttesting "k8s.io/client-go/testing"
+	// "k8s.io/client-go/tools/cache"
+	"k8s.io/kube-deploy/cluster-api/pkg/apis/cluster/v1alpha1"
+	"k8s.io/kube-deploy/cluster-api/pkg/apis/cluster/v1alpha1/testutil"
+	"k8s.io/kube-deploy/cluster-api/pkg/client/clientset_generated/clientset/fake"
+	clustercommon "k8s.io/kube-deploy/cluster-api/pkg/apis/cluster/common"
+	// v1alpha1listers "k8s.io/kube-deploy/cluster-api/pkg/client/listers_generated/cluster/v1alpha1"
+)
+
+type CountActuator struct{
+	CreateCallCount int64
+	DeleteCallCount int64
+	UpdateCallCount int64
+	ExistsCallCount int64
+	ExistsValue     bool
+}
+
+func (a *CountActuator) Create(*v1alpha1.Cluster, *v1alpha1.Machine) error {
+	a.CreateCallCount++
+	return nil
+}
+func (a *CountActuator) Delete(*v1alpha1.Machine) error {
+	a.DeleteCallCount++
+	return nil
+}
+func (a *CountActuator) Update(c *v1alpha1.Cluster, machine *v1alpha1.Machine) error {
+	a.UpdateCallCount++
+	return nil
+}
+func (a *CountActuator) Exists(*v1alpha1.Machine) (bool, error) {
+	a.ExistsCallCount++
+	return a.ExistsValue, nil
+}
+
+
+func TestMachineSetControllerReconcileHandler(t *testing.T) {
+	tests := []struct {
+		name                      string
+		objExists                 bool
+		instanceExists            bool
+		isDeleting                bool
+		withFinalizer             bool
+		isMaster                  bool
+		numExpectedCreateCalls    int64
+		numExpectedDeleteCalls    int64
+		numExpectedUpdateCalls    int64
+		numExpectedExistsCalls    int64
+	}{
+		{
+			name:                   "Create machine",
+			objExists:              false,
+			instanceExists:         false,
+			numExpectedCreateCalls: 1,
+			numExpectedExistsCalls: 1,
+		},
+		{
+			name:                   "Update machine",
+			objExists:              true,
+			instanceExists:         true,
+			numExpectedUpdateCalls: 1,
+			numExpectedExistsCalls: 1,
+		},
+		{
+			name:                   "Delete machine, instance exists, with finalizer",
+			objExists:              true,
+			instanceExists:         true,
+			isDeleting:             true,
+			withFinalizer:          true,
+			numExpectedDeleteCalls: 1,
+		},
+		{
+			name:                   "Delete machine, instance exists without finalizer",
+			objExists:              true,
+			instanceExists:         true,
+			isDeleting:             true,
+			withFinalizer:          false,
+		},
+		{
+			name:                   "Delete machine, instance does not exist, with finalizer",
+			objExists:              true,
+			instanceExists:         false,
+			isDeleting:             true,
+			withFinalizer:          true,
+			numExpectedDeleteCalls: 1,
+		},
+		{
+			name:                   "Delete machine, instance does not exist, without finalizer",
+			objExists:              true,
+			instanceExists:         false,
+			isDeleting:             true,
+			withFinalizer:          false,
+		},
+		{
+			name:                   "Delete machine, skip master",
+			objExists:              true,
+			instanceExists:         true,
+			isDeleting:             true,
+			withFinalizer:          true,
+			isMaster:               true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			machineToTest := getMachine("bar", test.isDeleting, test.withFinalizer, test.isMaster)
+			knownObjects := []runtime.Object{}
+			if test.objExists {
+				knownObjects = append(knownObjects, machineToTest)
+			}
+
+			fakeClient := fake.NewSimpleClientset(knownObjects...)
+			fakeMachineClient := fakeClient.Cluster().Machines(metav1.NamespaceDefault)
+
+			// When creating a new object, it should invoke the reconcile method.
+			cluster := testutil.GetVanillaCluster()
+			cluster.Name = "cluster-1"
+			if _, err := fakeClient.ClusterV1alpha1().Clusters(metav1.NamespaceDefault).Create(&cluster); err != nil {
+				t.Fatal(err)
+			}
+
+			actuator := &CountActuator{ExistsValue: test.instanceExists}
+
+			target := &MachineControllerImpl{}
+			target.actuator = actuator
+			target.clientSet = fakeClient
+			target.machineClient = fakeMachineClient
+
+			var err error
+			err = target.Reconcile(machineToTest)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if actuator.CreateCallCount != test.numExpectedCreateCalls {
+				t.Errorf("Got %v create calls, expected %v", actuator.CreateCallCount, test.numExpectedCreateCalls)
+			}
+			if actuator.DeleteCallCount != test.numExpectedDeleteCalls {
+				t.Errorf("Got %v delete calls, expected %v", actuator.DeleteCallCount, test.numExpectedDeleteCalls)
+			}
+			if actuator.UpdateCallCount != test.numExpectedUpdateCalls {
+				t.Errorf("Got %v update calls, expected %v", actuator.UpdateCallCount, test.numExpectedUpdateCalls)
+			}
+			if actuator.ExistsCallCount != test.numExpectedExistsCalls {
+				t.Errorf("Got %v exists calls, expected %v", actuator.ExistsCallCount, test.numExpectedExistsCalls)
+			}
+
+		})
+	}
+}
+
+func getMachine(name string, isDeleting, hasFinalizer, isMaster bool) *v1alpha1.Machine {
+	amachine := &v1alpha1.Machine{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Machine",
+			APIVersion: v1alpha1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Namespace: metav1.NamespaceDefault,
+		},
+	}
+	if isDeleting {
+		now := metav1.NewTime(time.Now())
+		amachine.ObjectMeta.SetDeletionTimestamp(&now)
+	}
+	if hasFinalizer {
+		amachine.ObjectMeta.SetFinalizers([]string{v1alpha1.MachineFinalizer})
+	}
+	if isMaster {
+		amachine.Spec.Roles = []clustercommon.MachineRole{clustercommon.MasterRole}
+	}
+
+	return amachine
+}

--- a/cluster-api/pkg/controller/machine/reconcile_test.go
+++ b/cluster-api/pkg/controller/machine/reconcile_test.go
@@ -183,7 +183,7 @@ func TestMachineSetControllerReconcileHandler(t *testing.T) {
 }
 
 func getMachine(name string, isDeleting, hasFinalizer, isMaster bool) *v1alpha1.Machine {
-	amachine := &v1alpha1.Machine{
+	m := &v1alpha1.Machine{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Machine",
 			APIVersion: v1alpha1.SchemeGroupVersion.String(),
@@ -195,14 +195,14 @@ func getMachine(name string, isDeleting, hasFinalizer, isMaster bool) *v1alpha1.
 	}
 	if isDeleting {
 		now := metav1.NewTime(time.Now())
-		amachine.ObjectMeta.SetDeletionTimestamp(&now)
+		m.ObjectMeta.SetDeletionTimestamp(&now)
 	}
 	if hasFinalizer {
-		amachine.ObjectMeta.SetFinalizers([]string{v1alpha1.MachineFinalizer})
+		m.ObjectMeta.SetFinalizers([]string{v1alpha1.MachineFinalizer})
 	}
 	if isMaster {
-		amachine.Spec.Roles = []clustercommon.MachineRole{clustercommon.MasterRole}
+		m.Spec.Roles = []clustercommon.MachineRole{clustercommon.MasterRole}
 	}
 
-	return amachine
+	return m
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
In the case of attempting to delete a machine object where the underlying instance does not exist, it may get stuck due to still having a finalizer.
Removing the machine finalizer will allow the machine object to be removed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

@kubernetes/kube-deploy-reviewers
