### PR TITLE
Use k8s GCR vanity URL

### DIFF
--- a/cluster-api/pkg/openapi/openapi_generated.go
+++ b/cluster-api/pkg/openapi/openapi_generated.go
@@ -8880,7 +8880,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 					Properties: map[string]spec.Schema{
 						"names": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Names by which this image is known. e.g. [\"gcr.io/google_containers/hyperkube:v1.0.7\", \"dockerhub.io/google_containers/hyperkube:v1.0.7\"]",
+								Description: "Names by which this image is known. e.g. [\"k8s.gcr.io/hyperkube:v1.0.7\", \"dockerhub.io/google_containers/hyperkube:v1.0.7\"]",
 								Type:        []string{"array"},
 								Items: &spec.SchemaOrArray{
 									Schema: &spec.Schema{


### PR DESCRIPTION
**Release note**:
NONE
```release-note

```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
