### PR TITLE
Remove Machine UID checking

### DIFF
--- a/cluster-api/cloud/google/instancestatus.go
+++ b/cluster-api/cloud/google/instancestatus.go
@@ -20,7 +20,7 @@ type instanceStatus *clusterv1.Machine
 
 // Get the status of the instance identified by the given machine
 func (gce *GCEClient) instanceStatus(machine *clusterv1.Machine) (instanceStatus, error) {
-	currentMachine, err := util.GetCurrentMachineIfExists(gce.machineClient, machine)
+	currentMachine, err := util.GetMachineIfExists(gce.machineClient, machine.ObjectMeta.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -36,7 +36,7 @@ func (gce *GCEClient) instanceStatus(machine *clusterv1.Machine) (instanceStatus
 // Sets the status of the instance identified by the given machine to the given machine
 func (gce *GCEClient) updateInstanceStatus(machine *clusterv1.Machine) error {
 	status := instanceStatus(machine)
-	currentMachine, err := util.GetCurrentMachineIfExists(gce.machineClient, machine)
+	currentMachine, err := util.GetMachineIfExists(gce.machineClient, machine.ObjectMeta.Name)
 	if err != nil {
 		return err
 	}

--- a/cluster-api/util/util.go
+++ b/cluster-api/util/util.go
@@ -130,10 +130,6 @@ func NewKubernetesClient(configPath string) (*kubernetes.Clientset, error) {
 	return c, nil
 }
 
-func GetCurrentMachineIfExists(machineClient client.MachineInterface, machine *clusterv1.Machine) (*clusterv1.Machine, error) {
-	return GetMachineIfExists(machineClient, machine.ObjectMeta.Name)
-}
-
 func GetMachineIfExists(machineClient client.MachineInterface, name string) (*clusterv1.Machine, error) {
 	if machineClient == nil {
 		// Being called before k8s is setup as part of master VM creation

--- a/cluster-api/util/util.go
+++ b/cluster-api/util/util.go
@@ -29,7 +29,6 @@ import (
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	clustercommon "k8s.io/kube-deploy/cluster-api/pkg/apis/cluster/common"
@@ -132,16 +131,16 @@ func NewKubernetesClient(configPath string) (*kubernetes.Clientset, error) {
 }
 
 func GetCurrentMachineIfExists(machineClient client.MachineInterface, machine *clusterv1.Machine) (*clusterv1.Machine, error) {
-	return GetMachineIfExists(machineClient, machine.ObjectMeta.Name, machine.ObjectMeta.UID)
+	return GetMachineIfExists(machineClient, machine.ObjectMeta.Name)
 }
 
-func GetMachineIfExists(machineClient client.MachineInterface, name string, uid types.UID) (*clusterv1.Machine, error) {
+func GetMachineIfExists(machineClient client.MachineInterface, name string) (*clusterv1.Machine, error) {
 	if machineClient == nil {
 		// Being called before k8s is setup as part of master VM creation
 		return nil, nil
 	}
 
-	// Machines are identified by name and UID
+	// Machines are identified by name
 	machine, err := machineClient.Get(name, metav1.GetOptions{})
 	if err != nil {
 		// TODO: Use formal way to check for not found
@@ -151,9 +150,6 @@ func GetMachineIfExists(machineClient client.MachineInterface, name string, uid 
 		return nil, err
 	}
 
-	if machine.ObjectMeta.UID != uid {
-		return nil, nil
-	}
 	return machine, nil
 }
 


### PR DESCRIPTION
Remove use of UID for identity checking since machine finalizers prevent machines with same name but different UIDs existing at the same time. The side benefit of not depending on UID is that bootstrapping could potentially pivot by copying objects instead of moving the actual ETCD files.

Bumping the official controller image will come after this PR merges.

Fixes #
```release-note

```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
