### PR TITLE
Implement a parallel queueworker for Machine Controller

### DIFF
--- a/cluster-api/cloud/google/cmd/gce-machine-controller/main.go
+++ b/cluster-api/cloud/google/cmd/gce-machine-controller/main.go
@@ -64,6 +64,6 @@ func main() {
 	// If this doesn't compile, the code generator probably
 	// overwrote the customized NewMachineController function.
 	c := machine.NewMachineController(config, si, actuator)
-	c.Run(shutdown)
+	c.RunAsync(shutdown)
 	select {}
 }

--- a/cluster-api/pkg/controller/machine/controller.go
+++ b/cluster-api/pkg/controller/machine/controller.go
@@ -48,6 +48,7 @@ type MachineControllerImpl struct {
 	clientSet           *clientset.Clientset
 	machineClient       v1alpha1.MachineInterface
 	linkedNodes         map[string]bool
+	syncChans           map[string]chan string
 }
 
 // Init initializes the controller and is called by the generated code
@@ -64,6 +65,7 @@ func (c *MachineControllerImpl) Init(arguments sharedinformers.ControllerInitArg
 	c.kubernetesClientSet = arguments.GetSharedInformers().KubernetesClientSet
 
 	c.linkedNodes = make(map[string]bool)
+	c.syncChans = make(map[string]chan string)
 
 	// Create machine actuator.
 	// TODO: Assume default namespace for now. Maybe a separate a controller per namespace?

--- a/cluster-api/pkg/controller/machine/queue.go
+++ b/cluster-api/pkg/controller/machine/queue.go
@@ -1,0 +1,89 @@
+package machine
+
+import (
+	"time"
+	"github.com/golang/glog"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"github.com/kubernetes-incubator/apiserver-builder/pkg/controller"
+)
+
+func (c *MachineController) RunAsync(stopCh <-chan struct{}) {
+	for _, q := range c.Informers.WorkerQueues {
+		c.StartWorkerQueue(q,stopCh)
+	}
+	controller.GetDefaults(c.controller).Run(stopCh)
+}
+
+// StartWorkerQueue schedules a routine to continuously process Queue messages
+// until shutdown is closed
+func (c *MachineController) StartWorkerQueue(q *controller.QueueWorker, shutdown <-chan struct{}) {
+	defer runtime.HandleCrash()
+	glog.Infof("Start %s Queue", q.Name)
+
+	// Every second, process all messages in the Queue until it is time to shutdown
+	go wait.Until(func(){c.ProcessAllMessages(q)}, time.Second, shutdown)
+
+	go func() {
+		<-shutdown
+
+		// Stop accepting messages into the Queue
+		glog.V(1).Infof("Shutting down %s Queue\n", q.Name)
+		q.Queue.ShutDown()
+	}()
+}
+
+// ProcessAllMessages tries to process all messages in the Queue
+func (c *MachineController) ProcessAllMessages(q *controller.QueueWorker) {
+	for done := false; !done; {
+		// Process all messages in the Queue
+		done = c.ProcessMessage(q)
+	}
+}
+
+// ProcessMessage tries to process the next message in the Queue, and requeues on an error
+func (c *MachineController) ProcessMessage(q *controller.QueueWorker) bool {
+	key, quit := q.Queue.Get()
+	if quit {
+		// Queue is empty
+		return true
+	}
+
+	// Create sync channel if needed.
+	syncChan, ok := c.controller.syncChans[key.(string)]
+	if !ok {
+		c.controller.syncChans[key.(string)] = make(chan string, 1)
+		syncChan = c.controller.syncChans[key.(string)]
+	}
+
+	go func() {
+		defer q.Queue.Done(key)
+		// sync against same machine resource. Allow only one reconcilation action in progress per
+		// machine resource.
+		syncChan <- key.(string)
+		defer func(){
+			<-syncChan
+			}()
+
+		// Do the work
+		err := q.Reconcile(key.(string))
+		if err == nil {
+			// Success.  Clear the requeue count for this key.
+			q.Queue.Forget(key)
+			return
+		}
+
+		// Error.  Maybe retry if haven't hit the limit.
+		if q.Queue.NumRequeues(key) < q.MaxRetries {
+			glog.V(4).Infof("Error handling %s Queue message %v: %v", q.Name, key, err)
+			q.Queue.AddRateLimited(key)
+			return
+		}
+
+		glog.V(4).Infof("Too many retries for %s Queue message %v: %v", q.Name, key, err)
+		q.Queue.Forget(key)
+
+	}()
+
+	return false
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR make reconciliation parallel per machine resource. It allows multiple reconciliation actions (create/delete/update) making progress simultaneously while serializing the reconciliation for the same machine resource.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
fixes #663

**Special notes for your reviewer**:
It was in the original CRD implementation, but get lost in apiserver aggregation migration. We might want to put this into apiserver-builder eventually if other controller can also benefit from this.

 
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
