### PR TITLE
Remove extra tab from CONTRIBUTING.md

### DIFF
--- a/cluster-api/gcp-deployer/CONTRIBUTING.md
+++ b/cluster-api/gcp-deployer/CONTRIBUTING.md
@@ -139,12 +139,13 @@ ERROR: (gcloud.config.get-value) Section [core] has no property [project].
 	```bash
 	$ ./gcp-deployer create -c cluster.yaml -m machines.yaml
 	```
-[Optional]To verify API server has been deployed successfully, you can the following command to double check.
+
+1. [Optional]To verify API server has been deployed successfully, you can the following command to double check.
 
 	```bash
 	$ kubectl get apiservices v1alpha1.cluster.k8s.io -o yaml
 	```
-    
+
 2. Edit the machine to trigger an update
 
 	```bash

--- a/cluster-api/gcp-deployer/CONTRIBUTING.md
+++ b/cluster-api/gcp-deployer/CONTRIBUTING.md
@@ -141,9 +141,9 @@ ERROR: (gcloud.config.get-value) Section [core] has no property [project].
 	```
 [Optional]To verify API server has been deployed successfully, you can the following command to double check.
 
-    ```bash
-    $ kubectl get apiservices v1alpha1.cluster.k8s.io -o yaml
-    ```
+	```bash
+	$ kubectl get apiservices v1alpha1.cluster.k8s.io -o yaml
+	```
     
 2. Edit the machine to trigger an update
 

--- a/cluster-api/gcp-deployer/CONTRIBUTING.md
+++ b/cluster-api/gcp-deployer/CONTRIBUTING.md
@@ -140,7 +140,7 @@ ERROR: (gcloud.config.get-value) Section [core] has no property [project].
 	$ ./gcp-deployer create -c cluster.yaml -m machines.yaml
 	```
 [Optional]To verify API server has been deployed successfully, you can the following command to double check.
-    
+
     ```bash
     $ kubectl get apiservices v1alpha1.cluster.k8s.io -o yaml
     ```


### PR DESCRIPTION
**What this PR does / why we need it**:
"```bash" is being shows literally rather than being rendered in markdown

@kubernetes/kube-deploy-reviewers
