### PR TITLE
Refactor GCEClient: wrap compute.Service in an interface for mocking …

### DIFF
--- a/cluster-api/cloud/google/clients/computeservice.go
+++ b/cluster-api/cloud/google/clients/computeservice.go
@@ -1,0 +1,62 @@
+package clients
+
+import (
+	compute "google.golang.org/api/compute/v1"
+	"net/http"
+	"net/url"
+)
+
+type ComputeService struct {
+	service *compute.Service
+}
+
+func NewComputeService(client *http.Client) (*ComputeService, error) {
+	return newComputeService(client)
+}
+
+func NewComputeServiceForURL(client *http.Client, baseURL string) (*ComputeService, error) {
+	ComputeServiceImpl, err := newComputeService(client)
+	if err != nil {
+		return nil, err
+	}
+	url, err := url.Parse(ComputeServiceImpl.service.BasePath)
+	if err != nil {
+		return nil, err
+	}
+	ComputeServiceImpl.service.BasePath = baseURL + url.Path
+	return ComputeServiceImpl, err
+}
+
+func newComputeService(client *http.Client) (*ComputeService, error) {
+	service, err := compute.New(client)
+	if err != nil {
+		return nil, err
+	}
+	return &ComputeService{
+		service: service,
+	}, nil
+}
+
+func (c *ComputeService) ImagesGet(project string, image string) (*compute.Image, error) {
+	return c.service.Images.Get(project, image).Do()
+}
+
+func (c *ComputeService) ImagesGetFromFamily(project string, family string) (*compute.Image, error) {
+	return c.service.Images.GetFromFamily(project, family).Do()
+}
+
+func (c *ComputeService) InstancesDelete(project string, zone string, targetInstance string) (*compute.Operation, error) {
+	return c.service.Instances.Delete(project, zone, targetInstance).Do()
+}
+
+func (c *ComputeService) InstancesGet(project string, zone string, instance string) (*compute.Instance, error) {
+	return c.service.Instances.Get(project, zone, instance).Do()
+}
+
+func (c *ComputeService) InstancesInsert(project string, zone string, instance *compute.Instance) (*compute.Operation, error) {
+	return c.service.Instances.Insert(project, zone, instance).Do()
+}
+
+func (c *ComputeService) ZoneOperationsGet(project string, zone string, operation string) (*compute.Operation, error) {
+	return c.service.ZoneOperations.Get(project, zone, operation).Do()
+}

--- a/cluster-api/cloud/google/clients/computeservice_test.go
+++ b/cluster-api/cloud/google/clients/computeservice_test.go
@@ -1,0 +1,121 @@
+package clients_test
+
+import (
+	compute "google.golang.org/api/compute/v1"
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/api/googleapi"
+	"k8s.io/kube-deploy/cluster-api/cloud/google/clients"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestImagesGet(t *testing.T) {
+	mux, server, client := createMuxServerAndClient()
+	defer server.Close()
+	responseImage := compute.Image{
+		Name:             "imageName",
+		ArchiveSizeBytes: 544,
+	}
+	mux.Handle("/compute/v1/projects/projectName/global/images/imageName", handler(nil, &responseImage))
+	image, err := client.ImagesGet("projectName", "imageName")
+	assert.Nil(t, err)
+	assert.NotNil(t, image)
+	assert.Equal(t, "imageName", image.Name)
+	assert.Equal(t, int64(544), image.ArchiveSizeBytes)
+}
+
+func TestImagesGetFromFamily(t *testing.T) {
+	mux, server, client := createMuxServerAndClient()
+	defer server.Close()
+	responseImage := compute.Image{
+		Name:             "imageName",
+		ArchiveSizeBytes: 544,
+	}
+	mux.Handle("/compute/v1/projects/projectName/global/images/family/familyName", handler(nil, &responseImage))
+	image, err := client.ImagesGetFromFamily("projectName", "familyName")
+	assert.Nil(t, err)
+	assert.NotNil(t, image)
+	assert.Equal(t, "imageName", image.Name)
+	assert.Equal(t, int64(544), image.ArchiveSizeBytes)
+}
+
+func TestInstancesDelete(t *testing.T) {
+	mux, server, client := createMuxServerAndClient()
+	defer server.Close()
+	responseOperation := compute.Operation{
+		Id: 4501,
+	}
+	mux.Handle("/compute/v1/projects/projectName/zones/zoneName/instances/instanceName", handler(nil, &responseOperation))
+	op, err := client.InstancesDelete("projectName", "zoneName", "instanceName")
+	assert.Nil(t, err)
+	assert.NotNil(t, op)
+	assert.Equal(t, uint64(4501), responseOperation.Id)
+}
+
+func TestInstancesGet(t *testing.T) {
+	mux, server, client := createMuxServerAndClient()
+	defer server.Close()
+	responseInstance := compute.Instance{
+		Name: "instanceName",
+		Zone: "zoneName",
+	}
+	mux.Handle("/compute/v1/projects/projectName/zones/zoneName/instances/instanceName", handler(nil, &responseInstance))
+	instance, err := client.InstancesGet("projectName", "zoneName", "instanceName")
+	assert.Nil(t, err)
+	assert.NotNil(t, instance)
+	assert.Equal(t, "instanceName", instance.Name)
+	assert.Equal(t, "zoneName", instance.Zone)
+}
+
+func TestInstancesInsert(t *testing.T) {
+	mux, server, client := createMuxServerAndClient()
+	defer server.Close()
+	responseOperation := compute.Operation{
+		Id: 3001,
+	}
+	mux.Handle("/compute/v1/projects/projectName/zones/zoneName/instances", handler(nil, &responseOperation))
+	op, err := client.InstancesInsert("projectName", "zoneName", nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, op)
+	assert.Equal(t, uint64(3001), responseOperation.Id)
+}
+
+func createMuxServerAndClient() (*http.ServeMux, *httptest.Server, *clients.ComputeService) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	client, _ := clients.NewComputeServiceForURL(server.Client(), server.URL)
+	return mux, server, client
+}
+
+func handler(err *googleapi.Error, obj interface{}) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		handleTestRequest(w, err, obj)
+	}
+}
+
+func handleTestRequest(w http.ResponseWriter, handleErr *googleapi.Error, obj interface{}) {
+	if handleErr != nil {
+		http.Error(w, errMsg(handleErr), handleErr.Code)
+		return
+	}
+	res, err := json.Marshal(obj)
+	if err != nil {
+		http.Error(w, "json marshal error", http.StatusInternalServerError)
+		return
+	}
+	w.Write(res)
+}
+
+func errMsg(e *googleapi.Error) string {
+	res, err := json.Marshal(&errorReply{e})
+	if err != nil {
+		return "json marshal error"
+	}
+	return string(res)
+}
+
+type errorReply struct {
+	Error *googleapi.Error `json:"error"`
+}


### PR DESCRIPTION
…GCP compute

This change creates a ComputeService interface which has a runtime
implementation that wraps the compute.Service. This will enable creating
tests that mock GCP Compute Service calls.

**What this PR does / why we need it**:
It is difficult to test changes that interact with GCP without manually running integration tests. This change will enable developers to write unit tests that mock GCP and test that their code correctly handles various scenarios. 

**Release note**:
```release-note
NONE
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
