### PR TITLE
[imagebuilder] new flag for injecting extra tags

### DIFF
--- a/imagebuilder/pkg/imagebuilder/config.go
+++ b/imagebuilder/pkg/imagebuilder/config.go
@@ -53,6 +53,7 @@ type AWSConfig struct {
 	SSHKeyName      string
 	SubnetID        string
 	SecurityGroupID string
+	Tags            map[string]string
 }
 
 func (c *AWSConfig) InitDefaults(region string) {
@@ -123,6 +124,7 @@ type GCEConfig struct {
 
 	MachineType string
 	Image       string
+	Tags        map[string]string
 }
 
 func (c *GCEConfig) InitDefaults() {


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a flag `-addtags` to allow specifying one or more additional tags to be injected into the `imagebuilder` configuration when using AWS. This has two purposes:

1. users operating in the same AWS account can use tags to select images

2. it also allows injecting extra runtime config into the `bootstrap-vz` templates. Possibly best explained with an example from my employer's internal CI job:

```
---
{{- define "gitref" -}}
{{- $ref := or .Tags.GitRef "" -}}
{{- if ne $ref "master" -}}
{{- printf "%s" $ref -}}
{{- end -}}
{{- end -}}
{{ if eq .Cloud "aws" }}
name: sm-k8s-1.8-debian-{system.release}-{system.architecture}-{provider.virtualization}-ebs-{%Y}-{%m}-{%d}{{ template "gitref" . }}
{{ else }}
name: k8s-1.8-debian-{system.release}-{system.architecture}-{%Y}-{%m}-{%d}{{- template "gitref" . }}
{{ end }}
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

N/A

**Special notes for your reviewer**:

Implemented for GCE... from what I can tell it looks correct, but untested

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Imagebuilder can now inject additional image tags into the AWS and GCE configuration to be applied to images and also visible in Go template context

```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
