### PR TITLE
Increase default IO timeout submitted to NVMe devices

### DIFF
--- a/imagebuilder/templates/1.10-jessie.yml
+++ b/imagebuilder/templates/1.10-jessie.yml
@@ -180,6 +180,9 @@ plugins:
        - [ 'chroot', '{root}', 'sed', '-i', 's/^GRUB_TIMEOUT=/#GRUB_TIMEOUT=/g', '/etc/default/grub' ]
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "# kubernetes image changes" >> /etc/default/grub' ]
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_CMDLINE_LINUX_DEFAULT=\"cgroup_enable=memory oops=panic panic=10 console=ttyS0\"" >> /etc/default/grub' ]
+{{ if eq .Cloud "aws" }}
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_CMDLINE_LINUX=\"${GRUB_CMDLINE_LINUX} nvme_core.io_timeout=255\"" >> /etc/default/grub' ]
+{{ end }}
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_TIMEOUT=0" >> /etc/default/grub' ]
        - [ 'chroot', '{root}', 'update-grub2' ]
 

--- a/imagebuilder/templates/1.10-stretch.yml
+++ b/imagebuilder/templates/1.10-stretch.yml
@@ -157,6 +157,9 @@ plugins:
        - [ 'chroot', '{root}', 'sed', '-i', 's/^GRUB_TIMEOUT=/#GRUB_TIMEOUT=/g', '/etc/default/grub' ]
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "# kubernetes image changes" >> /etc/default/grub' ]
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_CMDLINE_LINUX_DEFAULT=\"cgroup_enable=memory oops=panic panic=10 console=ttyS0\"" >> /etc/default/grub' ]
+{{ if eq .Cloud "aws" }}
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_CMDLINE_LINUX=\"${GRUB_CMDLINE_LINUX} nvme_core.io_timeout=255\"" >> /etc/default/grub' ]
+{{ end }}
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_TIMEOUT=0" >> /etc/default/grub' ]
        - [ 'chroot', '{root}', 'update-grub2' ]
 

--- a/imagebuilder/templates/1.11-jessie.yml
+++ b/imagebuilder/templates/1.11-jessie.yml
@@ -180,6 +180,9 @@ plugins:
        - [ 'chroot', '{root}', 'sed', '-i', 's/^GRUB_TIMEOUT=/#GRUB_TIMEOUT=/g', '/etc/default/grub' ]
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "# kubernetes image changes" >> /etc/default/grub' ]
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_CMDLINE_LINUX_DEFAULT=\"cgroup_enable=memory oops=panic panic=10 console=ttyS0\"" >> /etc/default/grub' ]
+{{ if eq .Cloud "aws" }}
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_CMDLINE_LINUX=\"${GRUB_CMDLINE_LINUX} nvme_core.io_timeout=255\"" >> /etc/default/grub' ]
+{{ end }}
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_TIMEOUT=0" >> /etc/default/grub' ]
        - [ 'chroot', '{root}', 'update-grub2' ]
 

--- a/imagebuilder/templates/1.11-stretch.yml
+++ b/imagebuilder/templates/1.11-stretch.yml
@@ -157,6 +157,9 @@ plugins:
        - [ 'chroot', '{root}', 'sed', '-i', 's/^GRUB_TIMEOUT=/#GRUB_TIMEOUT=/g', '/etc/default/grub' ]
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "# kubernetes image changes" >> /etc/default/grub' ]
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_CMDLINE_LINUX_DEFAULT=\"cgroup_enable=memory oops=panic panic=10 console=ttyS0\"" >> /etc/default/grub' ]
+{{ if eq .Cloud "aws" }}
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_CMDLINE_LINUX=\"${GRUB_CMDLINE_LINUX} nvme_core.io_timeout=255\"" >> /etc/default/grub' ]
+{{ end }}
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_TIMEOUT=0" >> /etc/default/grub' ]
        - [ 'chroot', '{root}', 'update-grub2' ]
 

--- a/imagebuilder/templates/1.2.yml
+++ b/imagebuilder/templates/1.2.yml
@@ -140,5 +140,8 @@ plugins:
        - [ 'chroot', '{root}', 'sed', '-i', 's/^GRUB_TIMEOUT=/#GRUB_TIMEOUT=/g', '/etc/default/grub' ]
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "# kubernetes image changes" >> /etc/default/grub' ]
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_CMDLINE_LINUX_DEFAULT=\"cgroup_enable=memory oops=panic panic=10 console=ttyS0\"" >> /etc/default/grub' ]
+{{ if eq .Cloud "aws" }}
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_CMDLINE_LINUX=\"${GRUB_CMDLINE_LINUX} nvme_core.io_timeout=255\"" >> /etc/default/grub' ]
+{{ end }}
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_TIMEOUT=0" >> /etc/default/grub' ]
        - [ 'chroot', '{root}', 'update-grub2' ]

--- a/imagebuilder/templates/1.3.yml
+++ b/imagebuilder/templates/1.3.yml
@@ -140,5 +140,8 @@ plugins:
        - [ 'chroot', '{root}', 'sed', '-i', 's/^GRUB_TIMEOUT=/#GRUB_TIMEOUT=/g', '/etc/default/grub' ]
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "# kubernetes image changes" >> /etc/default/grub' ]
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_CMDLINE_LINUX_DEFAULT=\"cgroup_enable=memory oops=panic panic=10 console=ttyS0\"" >> /etc/default/grub' ]
+{{ if eq .Cloud "aws" }}
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_CMDLINE_LINUX=\"${GRUB_CMDLINE_LINUX} nvme_core.io_timeout=255\"" >> /etc/default/grub' ]
+{{ end }}
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_TIMEOUT=0" >> /etc/default/grub' ]
        - [ 'chroot', '{root}', 'update-grub2' ]

--- a/imagebuilder/templates/1.4.yml
+++ b/imagebuilder/templates/1.4.yml
@@ -183,6 +183,9 @@ plugins:
        - [ 'chroot', '{root}', 'sed', '-i', 's/^GRUB_TIMEOUT=/#GRUB_TIMEOUT=/g', '/etc/default/grub' ]
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "# kubernetes image changes" >> /etc/default/grub' ]
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_CMDLINE_LINUX_DEFAULT=\"cgroup_enable=memory oops=panic panic=10 console=ttyS0\"" >> /etc/default/grub' ]
+{{ if eq .Cloud "aws" }}
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_CMDLINE_LINUX=\"${GRUB_CMDLINE_LINUX} nvme_core.io_timeout=255\"" >> /etc/default/grub' ]
+{{ end }}
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_TIMEOUT=0" >> /etc/default/grub' ]
        - [ 'chroot', '{root}', 'update-grub2' ]
 

--- a/imagebuilder/templates/1.5.yml
+++ b/imagebuilder/templates/1.5.yml
@@ -183,6 +183,9 @@ plugins:
        - [ 'chroot', '{root}', 'sed', '-i', 's/^GRUB_TIMEOUT=/#GRUB_TIMEOUT=/g', '/etc/default/grub' ]
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "# kubernetes image changes" >> /etc/default/grub' ]
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_CMDLINE_LINUX_DEFAULT=\"cgroup_enable=memory oops=panic panic=10 console=ttyS0\"" >> /etc/default/grub' ]
+{{ if eq .Cloud "aws" }}
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_CMDLINE_LINUX=\"${GRUB_CMDLINE_LINUX} nvme_core.io_timeout=255\"" >> /etc/default/grub' ]
+{{ end }}
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_TIMEOUT=0" >> /etc/default/grub' ]
        - [ 'chroot', '{root}', 'update-grub2' ]
 

--- a/imagebuilder/templates/1.6.yml
+++ b/imagebuilder/templates/1.6.yml
@@ -184,6 +184,9 @@ plugins:
        - [ 'chroot', '{root}', 'sed', '-i', 's/^GRUB_TIMEOUT=/#GRUB_TIMEOUT=/g', '/etc/default/grub' ]
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "# kubernetes image changes" >> /etc/default/grub' ]
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_CMDLINE_LINUX_DEFAULT=\"cgroup_enable=memory oops=panic panic=10 console=ttyS0\"" >> /etc/default/grub' ]
+{{ if eq .Cloud "aws" }}
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_CMDLINE_LINUX=\"${GRUB_CMDLINE_LINUX} nvme_core.io_timeout=255\"" >> /etc/default/grub' ]
+{{ end }}
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_TIMEOUT=0" >> /etc/default/grub' ]
        - [ 'chroot', '{root}', 'update-grub2' ]
 

--- a/imagebuilder/templates/1.7.yml
+++ b/imagebuilder/templates/1.7.yml
@@ -184,6 +184,9 @@ plugins:
        - [ 'chroot', '{root}', 'sed', '-i', 's/^GRUB_TIMEOUT=/#GRUB_TIMEOUT=/g', '/etc/default/grub' ]
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "# kubernetes image changes" >> /etc/default/grub' ]
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_CMDLINE_LINUX_DEFAULT=\"cgroup_enable=memory oops=panic panic=10 console=ttyS0\"" >> /etc/default/grub' ]
+{{ if eq .Cloud "aws" }}
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_CMDLINE_LINUX=\"${GRUB_CMDLINE_LINUX} nvme_core.io_timeout=255\"" >> /etc/default/grub' ]
+{{ end }}
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_TIMEOUT=0" >> /etc/default/grub' ]
        - [ 'chroot', '{root}', 'update-grub2' ]
 

--- a/imagebuilder/templates/1.8-jessie.yml
+++ b/imagebuilder/templates/1.8-jessie.yml
@@ -180,6 +180,9 @@ plugins:
        - [ 'chroot', '{root}', 'sed', '-i', 's/^GRUB_TIMEOUT=/#GRUB_TIMEOUT=/g', '/etc/default/grub' ]
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "# kubernetes image changes" >> /etc/default/grub' ]
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_CMDLINE_LINUX_DEFAULT=\"cgroup_enable=memory oops=panic panic=10 console=ttyS0\"" >> /etc/default/grub' ]
+{{ if eq .Cloud "aws" }}
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_CMDLINE_LINUX=\"${GRUB_CMDLINE_LINUX} nvme_core.io_timeout=255\"" >> /etc/default/grub' ]
+{{ end }}
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_TIMEOUT=0" >> /etc/default/grub' ]
        - [ 'chroot', '{root}', 'update-grub2' ]
 

--- a/imagebuilder/templates/1.8-stretch.yml
+++ b/imagebuilder/templates/1.8-stretch.yml
@@ -157,6 +157,9 @@ plugins:
        - [ 'chroot', '{root}', 'sed', '-i', 's/^GRUB_TIMEOUT=/#GRUB_TIMEOUT=/g', '/etc/default/grub' ]
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "# kubernetes image changes" >> /etc/default/grub' ]
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_CMDLINE_LINUX_DEFAULT=\"cgroup_enable=memory oops=panic panic=10 console=ttyS0\"" >> /etc/default/grub' ]
+{{ if eq .Cloud "aws" }}
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_CMDLINE_LINUX=\"${GRUB_CMDLINE_LINUX} nvme_core.io_timeout=255\"" >> /etc/default/grub' ]
+{{ end }}
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_TIMEOUT=0" >> /etc/default/grub' ]
        - [ 'chroot', '{root}', 'update-grub2' ]
 

--- a/imagebuilder/templates/1.9-jessie.yml
+++ b/imagebuilder/templates/1.9-jessie.yml
@@ -180,6 +180,9 @@ plugins:
        - [ 'chroot', '{root}', 'sed', '-i', 's/^GRUB_TIMEOUT=/#GRUB_TIMEOUT=/g', '/etc/default/grub' ]
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "# kubernetes image changes" >> /etc/default/grub' ]
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_CMDLINE_LINUX_DEFAULT=\"cgroup_enable=memory oops=panic panic=10 console=ttyS0\"" >> /etc/default/grub' ]
+{{ if eq .Cloud "aws" }}
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_CMDLINE_LINUX=\"${GRUB_CMDLINE_LINUX} nvme_core.io_timeout=255\"" >> /etc/default/grub' ]
+{{ end }}
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_TIMEOUT=0" >> /etc/default/grub' ]
        - [ 'chroot', '{root}', 'update-grub2' ]
 

--- a/imagebuilder/templates/1.9-stretch.yml
+++ b/imagebuilder/templates/1.9-stretch.yml
@@ -157,6 +157,9 @@ plugins:
        - [ 'chroot', '{root}', 'sed', '-i', 's/^GRUB_TIMEOUT=/#GRUB_TIMEOUT=/g', '/etc/default/grub' ]
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "# kubernetes image changes" >> /etc/default/grub' ]
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_CMDLINE_LINUX_DEFAULT=\"cgroup_enable=memory oops=panic panic=10 console=ttyS0\"" >> /etc/default/grub' ]
+{{ if eq .Cloud "aws" }}
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_CMDLINE_LINUX=\"${GRUB_CMDLINE_LINUX} nvme_core.io_timeout=255\"" >> /etc/default/grub' ]
+{{ end }}
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_TIMEOUT=0" >> /etc/default/grub' ]
        - [ 'chroot', '{root}', 'update-grub2' ]
 


### PR DESCRIPTION
**What this PR does / why we need it**:
For EC2 m5/c5 families, EBS volumes are exposed as NVMe block devices.
If there's a delay for AWS EBS to respond, we can reach NVMe IO timeout.
When this happens, the disk is re-mounted as read-only and no further writes can happen.
The default is 30 seconds.
AWS recommends to set it as high as possible. The newest Amazon Linux has this configured too.
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html#timeout-nvme-ebs-volumes
For the kernel version, the highest value is 255.

**Which issue(s) this PR fixes**:
https://github.com/kubernetes/kops/issues/5694

**Release note**:
```release-note
Increase nvme io timeout to better support EC2 c5/m5 instances.
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
