### PR TITLE
Add acpi-support to stretch images

### DIFF
--- a/imagebuilder/templates/1.10-stretch.yml
+++ b/imagebuilder/templates/1.10-stretch.yml
@@ -50,6 +50,9 @@ packages:
     # Important utils for administration
     # if minbase - openssh-server
 
+    # Ensure systemd scripts run on shutdown
+    - acpi-support
+
     # these packages are generally useful
     # (and are the ones from the GCE image)
     - rsync

--- a/imagebuilder/templates/1.11-stretch.yml
+++ b/imagebuilder/templates/1.11-stretch.yml
@@ -50,6 +50,9 @@ packages:
     # Important utils for administration
     # if minbase - openssh-server
 
+    # Ensure systemd scripts run on shutdown
+    - acpi-support
+
     # these packages are generally useful
     # (and are the ones from the GCE image)
     - rsync


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

acpi-support is needed for AWS to trigger systemd shutdown jobs
on instance shutdown or termination

Without acpi-support, the instance just gets hard powered off
approx 5 minutes after termination event fires without tidying
up at all

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes/kops/issues/4402

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adds acpi-support to 1.10 and 1.11 stretch images. This causes the instance to recognise that it is being shut down, allowing shutdown scripts to fire, and possibly reducing instance termination time.
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
