### PR TITLE
Dockerfile for imagebuilder

### DIFF
--- a/imagebuilder/.dockerignore
+++ b/imagebuilder/.dockerignore
@@ -1,3 +1,1 @@
-*~
 imagebuilder
-

--- a/imagebuilder/Dockerfile
+++ b/imagebuilder/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.11 AS build
+
+WORKDIR /go/src/k8s.io/kube-deploy/imagebuilder
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build
+
+FROM alpine:3.8
+WORKDIR /imagebuilder
+RUN apk add --no-cache ca-certificates
+COPY --from=build /go/src/k8s.io/kube-deploy/imagebuilder/imagebuilder imagebuilder
+ADD templates/ /imagebuilder/config/templates/
+ADD aws*.yaml gce*.yaml /imagebuilder/config/
+ENTRYPOINT ["/imagebuilder/imagebuilder"]


### PR DESCRIPTION
**What this PR does / why we need it**:

This can simplify usage of `imagebuilder` in CI pipelines.

**Which issue(s) this PR fixes**

Didn't find any obviously-relevant issues.

**Release note**:
```release-note
Dockerfile for imagebuilder
```

@kubernetes/kube-deploy-reviewers
