### PR TITLE
[WIP] AWS ARM64 support for Stretch builds

### DIFF
--- a/imagebuilder/README.md
+++ b/imagebuilder/README.md
@@ -123,6 +123,12 @@ configuration inputs. Some are specific to AWS or GCE.
 | `Tags`             | YAML map of cloud tags to be attached to the final cloud image                                    |
 | `TemplatePath`     | Path to `bootstrap-vz` template file, eg. `templates/1.11-stretch.yml`                            |
 
+ARM64 builds (work in progress)
+===============================
+
+Work is underway to support ARM64 on AWS. Pass the `--arch=arm64` option to try
+to build an AMI for ARM. This also requires modifications to `bootstrap-vz`.
+
 Advanced options
 ================
 

--- a/imagebuilder/main.go
+++ b/imagebuilder/main.go
@@ -51,6 +51,7 @@ var flagConfig = flag.String("config", "", "Config file to load")
 //var flagSecurityGroup = flag.String("securitygroup", "", "Security group to use for launch")
 //var flagTemplatePath = flag.String("template", "", "Path to image template")
 
+var flagArch = flag.String("arch", "amd64", "Architecture to build AMI for (currently supported: amd64, arm64)")
 var flagUp = flag.Bool("up", true, "Set to create instance (if not found)")
 var flagBuild = flag.Bool("build", true, "Set to build image")
 var flagTag = flag.Bool("tag", true, "Set to tag image")
@@ -338,7 +339,7 @@ func initAWS(useLocalhost bool) (*imagebuilder.AWSConfig, *imagebuilder.AWSCloud
 		region = os.Getenv("AWS_DEFAULT_REGION")
 	}
 	awsConfig := &imagebuilder.AWSConfig{}
-	awsConfig.InitDefaults(region)
+	awsConfig.InitDefaults(*flagArch, region)
 	err := loadConfig(awsConfig, *flagConfig)
 	if err != nil {
 		glog.Exitf("Error loading AWS config: %v", err)

--- a/imagebuilder/pkg/imagebuilder/aws-selections.go
+++ b/imagebuilder/pkg/imagebuilder/aws-selections.go
@@ -1,0 +1,73 @@
+package imagebuilder
+
+import (
+	"fmt"
+)
+
+// chooseAWSImage stores a list of
+func chooseAWSImage(arch, region string) (string, error) {
+	amis := make(map[string]map[string]string)
+	knownArchs := []string{"arm64", "amd64"}
+	for _, ka := range knownArchs {
+		amis[ka] = make(map[string]string)
+	}
+	// Debian 9.8 images from https://wiki.debian.org/Cloud/AmazonEC2Image/Stretch
+	amis["amd64"]["ap-northeast-1"] = "ami-0c4290d7ce45d7bbe"
+	amis["amd64"]["ap-northeast-2"] = "ami-0fa1392d5d545f9e8"
+	amis["amd64"]["ap-south-1"] = "ami-0b6490868957ce747"
+	amis["amd64"]["ap-southeast-1"] = "ami-04c9740a9ed018dba"
+	amis["amd64"]["ap-southeast-2"] = "ami-0b91189c4f9f5cd9e"
+	amis["amd64"]["ca-central-1"] = "ami-0857efbad274a1a89"
+	amis["amd64"]["eu-central-1"] = "ami-05449f21272b4ee56"
+	amis["amd64"]["eu-north-1"] = "ami-043a919b6dc7c51cc"
+	amis["amd64"]["eu-west-1"] = "ami-035c67e6a9ef8f024"
+	amis["amd64"]["eu-west-2"] = "ami-0ef10a4062f24d89d"
+	amis["amd64"]["eu-west-3"] = "ami-0cb185e7696ffe300"
+	amis["amd64"]["sa-east-1"] = "ami-0bc0ce4ab8b82305c"
+	amis["amd64"]["us-east-1"] = "ami-0f9e7e8867f55fd8e"
+	amis["amd64"]["us-east-2"] = "ami-00c5940f2b52c5d98"
+	amis["amd64"]["us-west-1"] = "ami-0afda78f1d0272d99"
+	amis["amd64"]["us-west-2"] = "ami-01d07e14f082b3ba1"
+	amis["arm64"]["ap-northeast-1"] = "ami-0fea662cdcd9b9dc9"
+	amis["arm64"]["ap-northeast-2"] = "ami-0399c4789441957b4"
+	amis["arm64"]["ap-south-1"] = "ami-0bd4d9e505ef0baed"
+	amis["arm64"]["ap-southeast-1"] = "ami-03a5c6bce47208f68"
+	amis["arm64"]["ap-southeast-2"] = "ami-04a251232bc12248d"
+	amis["arm64"]["ca-central-1"] = "ami-02827c87632b288a9"
+	amis["arm64"]["eu-central-1"] = "ami-0aeab0ea5ff2b82f8"
+	amis["arm64"]["eu-north-1"] = "ami-03c6ccf3b408e6b55"
+	amis["arm64"]["eu-west-1"] = "ami-0ef6a89d286837ca7"
+	amis["arm64"]["eu-west-2"] = "ami-0edc104967d61153e"
+	amis["arm64"]["eu-west-3"] = "ami-0bf9401479fab5f4b"
+	amis["arm64"]["sa-east-1"] = "ami-0c08b611b50b95e55"
+	amis["arm64"]["us-east-1"] = "ami-0e890f2e1ecc27745"
+	amis["arm64"]["us-east-2"] = "ami-0b9d7068010cf08c9"
+	amis["arm64"]["us-west-1"] = "ami-010e523aff65dce8a"
+	amis["arm64"]["us-west-2"] = "ami-046aead1494919fc1"
+	// A slightly older image, but the newest one we have
+	// FIXME: indicate provenance here?
+	amis["amd64"]["cn-north-1"] = "ami-da69a1b7"
+	if archMap, archOK := amis[arch]; archOK {
+		// arch is OK
+		if ami, amiOK := archMap[region]; amiOK {
+			return ami, nil
+		}
+		return "", fmt.Errorf("unknown region specified: %s", region)
+	}
+	return "", fmt.Errorf("unknown architecture specified: %s", arch)
+}
+
+// chooseAWSInstanceType handles the various quirks of instance type selection
+// An alternate approach might be to use the AWS Pricing API
+func chooseAWSInstanceType(arch, region string) string {
+	if region == "us-east-2" && arch == "amd64" {
+		// no m3.medium here
+		return "m4.large"
+	}
+	if arch == "arm64" {
+		// not available everywhere yet but rather than hardcode a list of
+		// functional regions, just let the instance launch fail
+		return "a1.medium"
+	}
+	return "m3.medium"
+}


### PR DESCRIPTION
Debian have updated their cloud images page for Stretch to include ARM64
AMIs: https://wiki.debian.org/Cloud/AmazonEC2Image/Stretch

* rearranged AMI selection
* updated AMI IDs for `amd64`
* added AMI IDs for `arm64`
* added a default instance type for `arm64`
* `amd64` still builds
* `arm64` does not quite work yet and requires some modifications to
  `bootstrap-vz`: https://github.com/jsleeio/bootstrap-vz/tree/arm64-support
  - current status: build breaks at `grub-install` with an EFI error
* while working on `bootstrap-vz` I branched from @andsens' current [`master`](https://github.com/andsens/bootstrap-vz) branch. Separately from this PR, I think we can move forward from @justinsb's [`image18`](https://github.com/justinsb/bootstrap-vz/tree/image18) branch to the current upstream release. TBC.
* there does not seem to be a Docker 17.03.2 [package](https://download.docker.com/linux/debian/dists/stretch/pool/stable/arm64/) for `arm64`.

**What this PR does / why we need it**:

Multi-architecture support for `imagebuilder` on AWS. This really means `arm64` for now, but I'm trying to squash as many arch-specific bits as possible

**Which issue(s) this PR fixes**

N/A

**Special notes for your reviewer**:

WIP, don't merge please!

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Nothing yet.
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
