### PR TITLE
Ensure we have deleted all our SSH keys

### DIFF
--- a/imagebuilder/templates/1.10-jessie.yml
+++ b/imagebuilder/templates/1.10-jessie.yml
@@ -193,6 +193,12 @@ plugins:
        # Remove machine-id, so that we regenerate next boot
        - [ 'rm', '-f', '{root}/etc/machine-id' ]
 
+       # Ensure we have cleaned up all our SSH keys
+       - [ 'chroot', '{root}', 'bin/sh', '-c', 'shred --remove /etc/ssh/ssh_host_*_key' ]
+       - [ 'chroot', '{root}', 'bin/sh', '-c', 'shred --remove /etc/ssh/ssh_host_*_key.pub' ]
+       # Workaround bootstrap-vz bug where it errors if all keys are removed
+       - [ 'chroot', '{root}', 'bin/sh', '-c', 'touch /etc/ssh/ssh_host_rsa_key.pub' ]
+
        # journald requires machine-id, so add a PreStart
        - [ 'chroot', '{root}', 'mkdir', '-p', '/etc/systemd/system/debian-fixup.service.d/' ]
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "[Service]" > /etc/systemd/system/debian-fixup.service.d/10-machineid.conf' ]

--- a/imagebuilder/templates/1.10-stretch.yml
+++ b/imagebuilder/templates/1.10-stretch.yml
@@ -173,6 +173,12 @@ plugins:
        # Remove machine-id, so that we regenerate next boot
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "" > /etc/machine-id' ]
 
+       # Ensure we have cleaned up all our SSH keys
+       - [ 'chroot', '{root}', 'bin/sh', '-c', 'shred --remove /etc/ssh/ssh_host_*_key' ]
+       - [ 'chroot', '{root}', 'bin/sh', '-c', 'shred --remove /etc/ssh/ssh_host_*_key.pub' ]
+       # Workaround bootstrap-vz bug where it errors if all keys are removed
+       - [ 'chroot', '{root}', 'bin/sh', '-c', 'touch /etc/ssh/ssh_host_rsa_key.pub' ]
+
        # journald requires machine-id, so add a PreStart
        - [ 'chroot', '{root}', 'mkdir', '-p', '/etc/systemd/system/debian-fixup.service.d/' ]
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "[Service]" > /etc/systemd/system/debian-fixup.service.d/10-machineid.conf' ]

--- a/imagebuilder/templates/1.11-jessie.yml
+++ b/imagebuilder/templates/1.11-jessie.yml
@@ -193,6 +193,12 @@ plugins:
        # Remove machine-id, so that we regenerate next boot
        - [ 'rm', '-f', '{root}/etc/machine-id' ]
 
+       # Ensure we have cleaned up all our SSH keys
+       - [ 'chroot', '{root}', 'bin/sh', '-c', 'shred --remove /etc/ssh/ssh_host_*_key' ]
+       - [ 'chroot', '{root}', 'bin/sh', '-c', 'shred --remove /etc/ssh/ssh_host_*_key.pub' ]
+       # Workaround bootstrap-vz bug where it errors if all keys are removed
+       - [ 'chroot', '{root}', 'bin/sh', '-c', 'touch /etc/ssh/ssh_host_rsa_key.pub' ]
+
        # journald requires machine-id, so add a PreStart
        - [ 'chroot', '{root}', 'mkdir', '-p', '/etc/systemd/system/debian-fixup.service.d/' ]
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "[Service]" > /etc/systemd/system/debian-fixup.service.d/10-machineid.conf' ]

--- a/imagebuilder/templates/1.11-stretch.yml
+++ b/imagebuilder/templates/1.11-stretch.yml
@@ -173,6 +173,12 @@ plugins:
        # Remove machine-id, so that we regenerate next boot
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "" > /etc/machine-id' ]
 
+       # Ensure we have cleaned up all our SSH keys
+       - [ 'chroot', '{root}', 'bin/sh', '-c', 'shred --remove /etc/ssh/ssh_host_*_key' ]
+       - [ 'chroot', '{root}', 'bin/sh', '-c', 'shred --remove /etc/ssh/ssh_host_*_key.pub' ]
+       # Workaround bootstrap-vz bug where it errors if all keys are removed
+       - [ 'chroot', '{root}', 'bin/sh', '-c', 'touch /etc/ssh/ssh_host_rsa_key.pub' ]
+
        # journald requires machine-id, so add a PreStart
        - [ 'chroot', '{root}', 'mkdir', '-p', '/etc/systemd/system/debian-fixup.service.d/' ]
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "[Service]" > /etc/systemd/system/debian-fixup.service.d/10-machineid.conf' ]

--- a/imagebuilder/templates/1.8-jessie.yml
+++ b/imagebuilder/templates/1.8-jessie.yml
@@ -193,6 +193,12 @@ plugins:
        # Remove machine-id, so that we regenerate next boot
        - [ 'rm', '-f', '{root}/etc/machine-id' ]
 
+       # Ensure we have cleaned up all our SSH keys
+       - [ 'chroot', '{root}', 'bin/sh', '-c', 'shred --remove /etc/ssh/ssh_host_*_key' ]
+       - [ 'chroot', '{root}', 'bin/sh', '-c', 'shred --remove /etc/ssh/ssh_host_*_key.pub' ]
+       # Workaround bootstrap-vz bug where it errors if all keys are removed
+       - [ 'chroot', '{root}', 'bin/sh', '-c', 'touch /etc/ssh/ssh_host_rsa_key.pub' ]
+
        # journald requires machine-id, so add a PreStart
        - [ 'chroot', '{root}', 'mkdir', '-p', '/etc/systemd/system/debian-fixup.service.d/' ]
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "[Service]" > /etc/systemd/system/debian-fixup.service.d/10-machineid.conf' ]

--- a/imagebuilder/templates/1.8-stretch.yml
+++ b/imagebuilder/templates/1.8-stretch.yml
@@ -170,6 +170,12 @@ plugins:
        # Remove machine-id, so that we regenerate next boot
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "" > /etc/machine-id' ]
 
+       # Ensure we have cleaned up all our SSH keys
+       - [ 'chroot', '{root}', 'bin/sh', '-c', 'shred --remove /etc/ssh/ssh_host_*_key' ]
+       - [ 'chroot', '{root}', 'bin/sh', '-c', 'shred --remove /etc/ssh/ssh_host_*_key.pub' ]
+       # Workaround bootstrap-vz bug where it errors if all keys are removed
+       - [ 'chroot', '{root}', 'bin/sh', '-c', 'touch /etc/ssh/ssh_host_rsa_key.pub' ]
+
        # journald requires machine-id, so add a PreStart
        - [ 'chroot', '{root}', 'mkdir', '-p', '/etc/systemd/system/debian-fixup.service.d/' ]
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "[Service]" > /etc/systemd/system/debian-fixup.service.d/10-machineid.conf' ]

--- a/imagebuilder/templates/1.9-jessie.yml
+++ b/imagebuilder/templates/1.9-jessie.yml
@@ -193,6 +193,12 @@ plugins:
        # Remove machine-id, so that we regenerate next boot
        - [ 'rm', '-f', '{root}/etc/machine-id' ]
 
+       # Ensure we have cleaned up all our SSH keys
+       - [ 'chroot', '{root}', 'bin/sh', '-c', 'shred --remove /etc/ssh/ssh_host_*_key' ]
+       - [ 'chroot', '{root}', 'bin/sh', '-c', 'shred --remove /etc/ssh/ssh_host_*_key.pub' ]
+       # Workaround bootstrap-vz bug where it errors if all keys are removed
+       - [ 'chroot', '{root}', 'bin/sh', '-c', 'touch /etc/ssh/ssh_host_rsa_key.pub' ]
+
        # journald requires machine-id, so add a PreStart
        - [ 'chroot', '{root}', 'mkdir', '-p', '/etc/systemd/system/debian-fixup.service.d/' ]
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "[Service]" > /etc/systemd/system/debian-fixup.service.d/10-machineid.conf' ]

--- a/imagebuilder/templates/1.9-stretch.yml
+++ b/imagebuilder/templates/1.9-stretch.yml
@@ -170,6 +170,12 @@ plugins:
        # Remove machine-id, so that we regenerate next boot
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "" > /etc/machine-id' ]
 
+       # Ensure we have cleaned up all our SSH keys
+       - [ 'chroot', '{root}', 'bin/sh', '-c', 'shred --remove /etc/ssh/ssh_host_*_key' ]
+       - [ 'chroot', '{root}', 'bin/sh', '-c', 'shred --remove /etc/ssh/ssh_host_*_key.pub' ]
+       # Workaround bootstrap-vz bug where it errors if all keys are removed
+       - [ 'chroot', '{root}', 'bin/sh', '-c', 'touch /etc/ssh/ssh_host_rsa_key.pub' ]
+
        # journald requires machine-id, so add a PreStart
        - [ 'chroot', '{root}', 'mkdir', '-p', '/etc/systemd/system/debian-fixup.service.d/' ]
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "[Service]" > /etc/systemd/system/debian-fixup.service.d/10-machineid.conf' ]


### PR DESCRIPTION
When new algorithms come along, we want to preemptively delete them.


```release-note
NONE
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers