### PR TITLE
Remove owners that are no longer actively contributing (including me).

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,24 +2,11 @@
 
 aliases:
   sig-cluster-lifecycle-leads:
-    - lukemarsden
+    - justinsb
     - luxas
-    - roberthbailey
     - timothysc
   kube-deploy-admins:
     - justinsb
-    - krousey
     - luxas
-    - roberthbailey
   kube-deploy-maintainers:
-    - jessicaochen
-    - karan
-    - kris-nova
-    - krousey
-    - medinatiger
-    - roberthbailey
-    - rsdcastro
-    - mkjelland
-    - spew
-    - johnsonj
-    - kcoronado
+    - justinsb


### PR DESCRIPTION
**What this PR does / why we need it**: Cleans up the owners file.

```release-note
NONE
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
